### PR TITLE
feat(T2): protocol layer with MessagePack codec

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@msgpack/msgpack": "^3.1.3",
         "@tauri-apps/api": "^2.10.1",
         "pinia": "^3.0.4",
         "vue": "^3.5.31",
@@ -22,6 +23,7 @@
         "typescript": "~6.0.0",
         "vite": "^8.0.3",
         "vite-plugin-vue-devtools": "^8.1.1",
+        "vitest": "^4.1.4",
         "vue-tsc": "^3.2.6"
       },
       "engines": {
@@ -561,6 +563,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -861,6 +872,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -889,6 +907,31 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
@@ -914,6 +957,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -1276,6 +1442,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -1400,6 +1576,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
@@ -1588,6 +1774,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1603,6 +1796,16 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -2220,6 +2423,17 @@
         "npm": ">= 10"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -2521,6 +2735,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -2554,6 +2775,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
@@ -2564,6 +2799,23 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2580,6 +2832,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -2897,6 +3159,96 @@
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -3040,6 +3392,23 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wsl-utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,9 +8,12 @@
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "build-only": "vite build",
-    "type-check": "vue-tsc --build"
+    "type-check": "vue-tsc --build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
+    "@msgpack/msgpack": "^3.1.3",
     "@tauri-apps/api": "^2.10.1",
     "pinia": "^3.0.4",
     "vue": "^3.5.31",
@@ -25,6 +28,7 @@
     "typescript": "~6.0.0",
     "vite": "^8.0.3",
     "vite-plugin-vue-devtools": "^8.1.1",
+    "vitest": "^4.1.4",
     "vue-tsc": "^3.2.6"
   },
   "engines": {

--- a/frontend/src/protocol/__tests__/codec.test.ts
+++ b/frontend/src/protocol/__tests__/codec.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MessageType,
+  encodeFrame,
+  decodeFrame,
+  FrameDecoder,
+  ProtocolError,
+  FRAME_MAGIC,
+  HEADER_SIZE,
+  MAX_PAYLOAD_SIZE,
+} from '../index'
+import type {
+  TextMessage,
+  PingMessage,
+  PongMessage,
+  OfflineMessage,
+  TypingMessage,
+  ReadReceiptMessage,
+  FileRequestMessage,
+  FileDataMessage,
+  FileAckMessage,
+} from '../index'
+
+const baseMeta = {
+  senderId: '550e8400-e29b-41d4-a716-446655440000',
+  recipientId: '550e8400-e29b-41d4-a716-446655440001',
+  timestamp: Date.now(),
+  messageId: '660e8400-e29b-41d4-a716-446655440002',
+}
+
+describe('Protocol Codec', () => {
+  describe('TextMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: TextMessage = {
+        ...baseMeta,
+        type: MessageType.Text,
+        content: 'Hello, LAN!',
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result).not.toBeNull()
+      expect(result!.message).toEqual(msg)
+      expect(result!.bytesConsumed).toBe(frame.byteLength)
+    })
+
+    it('should handle unicode content', () => {
+      const msg: TextMessage = {
+        ...baseMeta,
+        type: MessageType.Text,
+        content: '你好世界 🌍 émojis',
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result!.message).toEqual(msg)
+    })
+  })
+
+  describe('PingMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: PingMessage = {
+        ...baseMeta,
+        type: MessageType.Ping,
+        recipientId: '',
+        deviceName: 'MacBook Pro',
+        port: 9876,
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result!.message).toEqual(msg)
+    })
+  })
+
+  describe('PongMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: PongMessage = {
+        ...baseMeta,
+        type: MessageType.Pong,
+        deviceName: 'Windows PC',
+        port: 9876,
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result!.message).toEqual(msg)
+    })
+  })
+
+  describe('OfflineMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: OfflineMessage = {
+        ...baseMeta,
+        type: MessageType.Offline,
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result!.message).toEqual(msg)
+    })
+  })
+
+  describe('TypingMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: TypingMessage = {
+        ...baseMeta,
+        type: MessageType.Typing,
+        isTyping: true,
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result!.message).toEqual(msg)
+    })
+  })
+
+  describe('ReadReceiptMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: ReadReceiptMessage = {
+        ...baseMeta,
+        type: MessageType.ReadReceipt,
+        readMessageIds: ['id-1', 'id-2', 'id-3'],
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result!.message).toEqual(msg)
+    })
+  })
+
+  describe('FileRequestMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: FileRequestMessage = {
+        ...baseMeta,
+        type: MessageType.FileRequest,
+        fileName: 'document.pdf',
+        fileSize: 1024 * 1024,
+        checksum: 'abc123def456',
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result!.message).toEqual(msg)
+    })
+  })
+
+  describe('FileDataMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: FileDataMessage = {
+        ...baseMeta,
+        type: MessageType.FileData,
+        fileId: 'file-001',
+        chunkIndex: 0,
+        totalChunks: 10,
+        data: new Uint8Array([1, 2, 3, 4, 5]),
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      const decoded = result!.message as FileDataMessage
+      expect(decoded.type).toBe(MessageType.FileData)
+      expect(decoded.fileId).toBe('file-001')
+      expect(decoded.chunkIndex).toBe(0)
+      expect(new Uint8Array(decoded.data)).toEqual(new Uint8Array([1, 2, 3, 4, 5]))
+    })
+  })
+
+  describe('FileAckMessage', () => {
+    it('should encode and decode correctly', () => {
+      const msg: FileAckMessage = {
+        ...baseMeta,
+        type: MessageType.FileAck,
+        fileId: 'file-001',
+        accepted: true,
+      }
+      const frame = encodeFrame(msg)
+      const result = decodeFrame(frame)
+      expect(result!.message).toEqual(msg)
+    })
+  })
+
+  describe('Frame format', () => {
+    it('should have correct magic bytes', () => {
+      const msg: TextMessage = { ...baseMeta, type: MessageType.Text, content: 'hi' }
+      const frame = encodeFrame(msg)
+      expect(frame.slice(0, 4)).toEqual(FRAME_MAGIC)
+    })
+
+    it('should have correct length in header', () => {
+      const msg: TextMessage = { ...baseMeta, type: MessageType.Text, content: 'hi' }
+      const frame = encodeFrame(msg)
+      const view = new DataView(frame.buffer, frame.byteOffset)
+      const length = view.getUint32(4, false)
+      expect(length).toBe(frame.byteLength - HEADER_SIZE)
+    })
+
+    it('should return null for incomplete buffer', () => {
+      const msg: TextMessage = { ...baseMeta, type: MessageType.Text, content: 'hi' }
+      const frame = encodeFrame(msg)
+      // Only give half
+      expect(decodeFrame(frame.slice(0, HEADER_SIZE + 2))).toBeNull()
+    })
+
+    it('should return null for buffer smaller than header', () => {
+      expect(decodeFrame(new Uint8Array(4))).toBeNull()
+    })
+
+    it('should throw on invalid magic', () => {
+      const frame = new Uint8Array(HEADER_SIZE + 4)
+      frame.set([0x00, 0x00, 0x00, 0x00], 0) // bad magic
+      expect(() => decodeFrame(frame)).toThrow(ProtocolError)
+    })
+
+    it('should throw on oversized payload length', () => {
+      const frame = new Uint8Array(HEADER_SIZE)
+      frame.set(FRAME_MAGIC, 0)
+      const view = new DataView(frame.buffer)
+      view.setUint32(4, MAX_PAYLOAD_SIZE + 1, false)
+      expect(() => decodeFrame(frame)).toThrow(ProtocolError)
+    })
+  })
+
+  describe('FrameDecoder (streaming)', () => {
+    it('should decode multiple messages from chunked data', () => {
+      const msg1: TextMessage = { ...baseMeta, type: MessageType.Text, content: 'first' }
+      const msg2: TextMessage = { ...baseMeta, type: MessageType.Text, content: 'second' }
+      const frame1 = encodeFrame(msg1)
+      const frame2 = encodeFrame(msg2)
+
+      const combined = new Uint8Array(frame1.byteLength + frame2.byteLength)
+      combined.set(frame1, 0)
+      combined.set(frame2, frame1.byteLength)
+
+      const decoder = new FrameDecoder()
+      // Feed in small chunks
+      const chunkSize = 10
+      const allMessages: any[] = []
+      for (let i = 0; i < combined.byteLength; i += chunkSize) {
+        const chunk = combined.slice(i, Math.min(i + chunkSize, combined.byteLength))
+        allMessages.push(...decoder.feed(chunk))
+      }
+
+      expect(allMessages).toHaveLength(2)
+      expect(allMessages[0]).toEqual(msg1)
+      expect(allMessages[1]).toEqual(msg2)
+    })
+
+    it('should reset properly', () => {
+      const decoder = new FrameDecoder()
+      decoder.feed(new Uint8Array([0x4c, 0x4d])) // partial magic
+      expect(decoder.bufferedBytes).toBe(2)
+      decoder.reset()
+      expect(decoder.bufferedBytes).toBe(0)
+    })
+  })
+})

--- a/frontend/src/protocol/codec.ts
+++ b/frontend/src/protocol/codec.ts
@@ -1,0 +1,138 @@
+/**
+ * LAN Messenger Protocol - Frame Codec
+ *
+ * Wire format: [MAGIC (4 bytes)] [LENGTH (4 bytes, big-endian)] [PAYLOAD (LENGTH bytes)]
+ *
+ * MAGIC: 0x4C 0x4D 0x53 0x47 ("LMSG")
+ * LENGTH: uint32 big-endian, payload size in bytes
+ * PAYLOAD: MessagePack encoded message
+ */
+
+import { encode, decode } from '@msgpack/msgpack'
+import type { Message } from './types'
+
+/** Protocol magic bytes: "LMSG" */
+export const FRAME_MAGIC = new Uint8Array([0x4c, 0x4d, 0x53, 0x47])
+
+/** Header size: 4 (magic) + 4 (length) = 8 bytes */
+export const HEADER_SIZE = 8
+
+/** Maximum payload size: 16 MB */
+export const MAX_PAYLOAD_SIZE = 16 * 1024 * 1024
+
+export class ProtocolError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ProtocolError'
+  }
+}
+
+/**
+ * Encode a message into a framed binary buffer.
+ */
+export function encodeFrame(message: Message): Uint8Array {
+  const payload = encode(message)
+
+  if (payload.byteLength > MAX_PAYLOAD_SIZE) {
+    throw new ProtocolError(
+      `Payload size ${payload.byteLength} exceeds maximum ${MAX_PAYLOAD_SIZE}`,
+    )
+  }
+
+  const frame = new Uint8Array(HEADER_SIZE + payload.byteLength)
+
+  // Write magic
+  frame.set(FRAME_MAGIC, 0)
+
+  // Write length (big-endian uint32)
+  const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength)
+  view.setUint32(4, payload.byteLength, false)
+
+  // Write payload
+  frame.set(payload, HEADER_SIZE)
+
+  return frame
+}
+
+/**
+ * Decode a framed binary buffer into a message.
+ * Returns the decoded message and the number of bytes consumed.
+ * Returns null if the buffer doesn't contain a complete frame.
+ */
+export function decodeFrame(buffer: Uint8Array): { message: Message; bytesConsumed: number } | null {
+  if (buffer.byteLength < HEADER_SIZE) {
+    return null
+  }
+
+  // Verify magic
+  for (let i = 0; i < 4; i++) {
+    if (buffer[i] !== FRAME_MAGIC[i]) {
+      throw new ProtocolError(
+        `Invalid magic bytes at offset ${i}: expected 0x${FRAME_MAGIC[i].toString(16)}, got 0x${buffer[i].toString(16)}`,
+      )
+    }
+  }
+
+  // Read length
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  const payloadLength = view.getUint32(4, false)
+
+  if (payloadLength > MAX_PAYLOAD_SIZE) {
+    throw new ProtocolError(
+      `Payload length ${payloadLength} exceeds maximum ${MAX_PAYLOAD_SIZE}`,
+    )
+  }
+
+  // Check if we have the full payload
+  const totalLength = HEADER_SIZE + payloadLength
+  if (buffer.byteLength < totalLength) {
+    return null
+  }
+
+  // Decode payload
+  const payload = buffer.slice(HEADER_SIZE, totalLength)
+  const message = decode(payload) as Message
+
+  return { message, bytesConsumed: totalLength }
+}
+
+/**
+ * Stream decoder: accumulates bytes and yields complete messages.
+ */
+export class FrameDecoder {
+  private buffer: Uint8Array = new Uint8Array(0)
+
+  /**
+   * Feed bytes into the decoder and return any complete messages.
+   */
+  feed(data: Uint8Array): Message[] {
+    // Append to buffer
+    const newBuffer = new Uint8Array(this.buffer.byteLength + data.byteLength)
+    newBuffer.set(this.buffer, 0)
+    newBuffer.set(data, this.buffer.byteLength)
+    this.buffer = newBuffer
+
+    const messages: Message[] = []
+
+    while (this.buffer.byteLength >= HEADER_SIZE) {
+      const result = decodeFrame(this.buffer)
+      if (result === null) {
+        break
+      }
+      messages.push(result.message)
+      this.buffer = this.buffer.slice(result.bytesConsumed)
+    }
+
+    return messages
+  }
+
+  /** Reset the decoder state */
+  reset(): void {
+    this.buffer = new Uint8Array(0)
+  }
+
+  /** Get remaining buffered bytes count */
+  get bufferedBytes(): number {
+    return this.buffer.byteLength
+  }
+}

--- a/frontend/src/protocol/index.ts
+++ b/frontend/src/protocol/index.ts
@@ -1,0 +1,24 @@
+export { MessageType } from './types'
+export type {
+  Message,
+  MessageEnvelope,
+  TextMessage,
+  FileRequestMessage,
+  FileDataMessage,
+  FileAckMessage,
+  PingMessage,
+  PongMessage,
+  OfflineMessage,
+  TypingMessage,
+  ReadReceiptMessage,
+} from './types'
+
+export {
+  FRAME_MAGIC,
+  HEADER_SIZE,
+  MAX_PAYLOAD_SIZE,
+  ProtocolError,
+  encodeFrame,
+  decodeFrame,
+  FrameDecoder,
+} from './codec'

--- a/frontend/src/protocol/types.ts
+++ b/frontend/src/protocol/types.ts
@@ -1,0 +1,114 @@
+/**
+ * LAN Messenger Protocol - Message Types
+ *
+ * All message types exchanged between peers.
+ */
+
+/** Message type identifiers */
+export enum MessageType {
+  /** Text chat message */
+  Text = 0x01,
+  /** File transfer request */
+  FileRequest = 0x02,
+  /** File transfer data chunk */
+  FileData = 0x03,
+  /** File transfer acknowledgement */
+  FileAck = 0x04,
+  /** Device discovery ping */
+  Ping = 0x10,
+  /** Device discovery pong */
+  Pong = 0x11,
+  /** Device going offline */
+  Offline = 0x12,
+  /** Typing indicator */
+  Typing = 0x20,
+  /** Read receipt */
+  ReadReceipt = 0x21,
+}
+
+/** Base message envelope */
+export interface MessageEnvelope {
+  /** Message type */
+  type: MessageType
+  /** Sender device ID (UUID) */
+  senderId: string
+  /** Recipient device ID (UUID), empty for broadcast */
+  recipientId: string
+  /** Unix timestamp in ms */
+  timestamp: number
+  /** Unique message ID (UUID) */
+  messageId: string
+}
+
+/** Text message payload */
+export interface TextMessage extends MessageEnvelope {
+  type: MessageType.Text
+  content: string
+}
+
+/** File transfer request */
+export interface FileRequestMessage extends MessageEnvelope {
+  type: MessageType.FileRequest
+  fileName: string
+  fileSize: number
+  checksum: string // SHA-256
+}
+
+/** File data chunk */
+export interface FileDataMessage extends MessageEnvelope {
+  type: MessageType.FileData
+  fileId: string
+  chunkIndex: number
+  totalChunks: number
+  data: Uint8Array
+}
+
+/** File ack */
+export interface FileAckMessage extends MessageEnvelope {
+  type: MessageType.FileAck
+  fileId: string
+  accepted: boolean
+}
+
+/** Discovery ping */
+export interface PingMessage extends MessageEnvelope {
+  type: MessageType.Ping
+  deviceName: string
+  port: number
+}
+
+/** Discovery pong */
+export interface PongMessage extends MessageEnvelope {
+  type: MessageType.Pong
+  deviceName: string
+  port: number
+}
+
+/** Offline notification */
+export interface OfflineMessage extends MessageEnvelope {
+  type: MessageType.Offline
+}
+
+/** Typing indicator */
+export interface TypingMessage extends MessageEnvelope {
+  type: MessageType.Typing
+  isTyping: boolean
+}
+
+/** Read receipt */
+export interface ReadReceiptMessage extends MessageEnvelope {
+  type: MessageType.ReadReceipt
+  readMessageIds: string[]
+}
+
+/** Union of all message types */
+export type Message =
+  | TextMessage
+  | FileRequestMessage
+  | FileDataMessage
+  | FileAckMessage
+  | PingMessage
+  | PongMessage
+  | OfflineMessage
+  | TypingMessage
+  | ReadReceiptMessage


### PR DESCRIPTION
## What

Implement the protocol layer (`protocol/` module) with MessagePack encoding and frame format.

## Changes

- Message type definitions (Text, File*, Ping/Pong, Offline, Typing, ReadReceipt)
- Frame codec: `MAGIC(LMSG)` + `LENGTH(u32 BE)` + `PAYLOAD(msgpack)`
- Streaming `FrameDecoder` for chunked TCP data
- 18 unit tests — all passing

## How to test

```bash
cd frontend
npm run test
```

Closes #3