### PR TITLE
feat(T3): device discovery service with UDP broadcast

### DIFF
--- a/frontend/src-tauri/src/discovery/mod.rs
+++ b/frontend/src-tauri/src/discovery/mod.rs
@@ -1,0 +1,3 @@
+pub mod udp;
+
+pub use udp::DiscoveryService;

--- a/frontend/src-tauri/src/discovery/udp.rs
+++ b/frontend/src-tauri/src/discovery/udp.rs
@@ -1,0 +1,223 @@
+use std::collections::HashMap;
+use std::net::{SocketAddr, UdpSocket, Ipv4Addr};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+const BROADCAST_ADDR: Ipv4Addr = Ipv4Addr::new(255, 255, 255, 255);
+const MAGIC: &[u8; 4] = b"LMSG";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerInfo {
+    pub id: String,
+    pub name: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveredPeer {
+    pub info: PeerInfo,
+    pub addr: SocketAddr,
+    pub last_seen: Instant,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum DiscoveryPacket {
+    Ping(PeerInfo),
+    Pong(PeerInfo),
+    Offline(String), // device_id
+}
+
+pub enum DiscoveryEvent {
+    PeerFound(DiscoveredPeer),
+    PeerLost(String), // device_id
+    PeerUpdated(DiscoveredPeer),
+}
+
+pub struct DiscoveryConfig {
+    pub broadcast_port: u16,
+    pub heartbeat_interval: Duration,
+    pub timeout_threshold: Duration,
+    pub device_id: String,
+    pub device_name: String,
+    pub service_port: u16,
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            broadcast_port: 19876,
+            heartbeat_interval: Duration::from_secs(30),
+            timeout_threshold: Duration::from_secs(90),
+            device_id: String::new(),
+            device_name: String::new(),
+            service_port: 0,
+        }
+    }
+}
+
+pub struct DiscoveryService {
+    config: DiscoveryConfig,
+    peers: Arc<Mutex<HashMap<String, DiscoveredPeer>>>,
+    running: Arc<Mutex<bool>>,
+    event_tx: Option<std::sync::mpsc::Sender<DiscoveryEvent>>,
+}
+
+impl DiscoveryService {
+    pub fn new(
+        config: DiscoveryConfig,
+        event_tx: std::sync::mpsc::Sender<DiscoveryEvent>,
+    ) -> Self {
+        Self {
+            config,
+            peers: Arc::new(Mutex::new(HashMap::new())),
+            running: Arc::new(Mutex::new(false)),
+            event_tx: Some(event_tx),
+        }
+    }
+
+    pub fn start(&self) -> std::io::Result<()> {
+        {
+            let mut running = self.running.lock().unwrap();
+            if *running {
+                return Ok(());
+            }
+            *running = true;
+        }
+
+        let socket = UdpSocket::bind(("0.0.0.0", self.config.broadcast_port))?;
+        socket.set_broadcast(true)?;
+        socket.set_read_timeout(Some(Duration::from_secs(1)))?;
+
+        let recv_socket = socket.try_clone()?;
+
+        // Heartbeat sender thread
+        let running = Arc::clone(&self.running);
+        let broadcast_port = self.config.broadcast_port;
+        let heartbeat_interval = self.config.heartbeat_interval;
+        let my_info = PeerInfo {
+            id: self.config.device_id.clone(),
+            name: self.config.device_name.clone(),
+            port: self.config.service_port,
+        };
+
+        let send_info = my_info.clone();
+        thread::spawn(move || {
+            let packet = DiscoveryPacket::Ping(send_info);
+            let data = rmp_serde::to_vec(&packet).unwrap();
+            let mut frame = Vec::with_capacity(MAGIC.len() + data.len());
+            frame.extend_from_slice(MAGIC);
+            frame.extend_from_slice(&data);
+
+            let addr = SocketAddr::new(BROADCAST_ADDR.into(), broadcast_port);
+            while *running.lock().unwrap() {
+                let _ = socket.send_to(&frame, addr);
+                thread::sleep(heartbeat_interval);
+            }
+
+            // Send offline notification
+            let offline = DiscoveryPacket::Offline(packet_id(&packet));
+            if let Ok(data) = rmp_serde::to_vec(&offline) {
+                let mut frame = Vec::with_capacity(MAGIC.len() + data.len());
+                frame.extend_from_slice(MAGIC);
+                frame.extend_from_slice(&data);
+                let _ = socket.send_to(&frame, addr);
+            }
+        });
+
+        // Receiver thread
+        let peers = Arc::clone(&self.peers);
+        let running = Arc::clone(&self.running);
+        let timeout = self.config.timeout_threshold;
+        let my_id = self.config.device_id.clone();
+        let event_tx = self.event_tx.clone();
+
+        thread::spawn(move || {
+            let mut buf = [0u8; 65535];
+            while *running.lock().unwrap() {
+                // Check timeouts
+                {
+                    let mut peers = peers.lock().unwrap();
+                    let now = Instant::now();
+                    let timed_out: Vec<String> = peers
+                        .iter()
+                        .filter(|(_, p)| now.duration_since(p.last_seen) > timeout)
+                        .map(|(id, _)| id.clone())
+                        .collect();
+                    for id in timed_out {
+                        peers.remove(&id);
+                        if let Some(tx) = &event_tx {
+                            let _ = tx.send(DiscoveryEvent::PeerLost(id));
+                        }
+                    }
+                }
+
+                match recv_socket.recv_from(&mut buf) {
+                    Ok((n, addr)) => {
+                        if n < MAGIC.len() || &buf[..4] != MAGIC {
+                            continue;
+                        }
+                        let data = &buf[MAGIC.len()..n];
+                        let packet: DiscoveryPacket = match rmp_serde::from_slice(data) {
+                            Ok(p) => p,
+                            Err(_) => continue,
+                        };
+
+                        match packet {
+                            DiscoveryPacket::Ping(info) | DiscoveryPacket::Pong(info) => {
+                                if info.id == my_id {
+                                    continue; // Ignore our own broadcasts
+                                }
+                                let mut peers = peers.lock().unwrap();
+                                let is_new = !peers.contains_key(&info.id);
+                                let peer = DiscoveredPeer {
+                                    info: info.clone(),
+                                    addr,
+                                    last_seen: Instant::now(),
+                                };
+                                peers.insert(info.id.clone(), peer.clone());
+
+                                if let Some(tx) = &event_tx {
+                                    if is_new {
+                                        let _ = tx.send(DiscoveryEvent::PeerFound(peer));
+                                    } else {
+                                        let _ = tx.send(DiscoveryEvent::PeerUpdated(peer));
+                                    }
+                                }
+                            }
+                            DiscoveryPacket::Offline(id) => {
+                                let mut peers = peers.lock().unwrap();
+                                if peers.remove(&id).is_some() {
+                                    if let Some(tx) = &event_tx {
+                                        let _ = tx.send(DiscoveryEvent::PeerLost(id));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(_) => continue, // timeout, just loop
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    pub fn stop(&self) {
+        let mut running = self.running.lock().unwrap();
+        *running = false;
+    }
+
+    pub fn get_peers(&self) -> Vec<DiscoveredPeer> {
+        self.peers.lock().unwrap().values().cloned().collect()
+    }
+}
+
+fn packet_id(packet: &DiscoveryPacket) -> String {
+    match packet {
+        DiscoveryPacket::Ping(info) | DiscoveryPacket::Pong(info) => info.id.clone(),
+        DiscoveryPacket::Offline(id) => id.clone(),
+    }
+}

--- a/frontend/src/discovery/__tests__/discovery.test.ts
+++ b/frontend/src/discovery/__tests__/discovery.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MockDiscoveryService, DiscoveryEvent } from '../index'
+import type { Peer, DiscoveryEventHandler } from '../index'
+
+let service: MockDiscoveryService
+let events: Array<{ event: string; peer: Peer }>
+let handler: DiscoveryEventHandler
+
+beforeEach(() => {
+  service = new MockDiscoveryService({
+    deviceId: 'my-device',
+    deviceName: 'My PC',
+    servicePort: 9876,
+    timeoutThreshold: 90_000,
+  })
+  events = []
+  handler = (event, peer) => events.push({ event, peer })
+  service.on(handler)
+  service.start()
+})
+
+describe('DiscoveryService', () => {
+  it('should start and stop', () => {
+    expect(service.isRunning).toBe(true)
+    service.stop()
+    expect(service.isRunning).toBe(false)
+  })
+
+  it('should discover new peer', () => {
+    service.simulatePeerPing({
+      id: 'peer-1',
+      name: 'Peer One',
+      ipAddress: '192.168.1.101',
+      port: 9876,
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe(DiscoveryEvent.PeerFound)
+    expect(events[0].peer.id).toBe('peer-1')
+    expect(service.getPeers()).toHaveLength(1)
+  })
+
+  it('should not re-emit PeerFound on heartbeat', () => {
+    const peer = { id: 'peer-1', name: 'Peer', ipAddress: '192.168.1.101', port: 9876 }
+    service.simulatePeerPing(peer)
+    service.simulatePeerPing(peer) // heartbeat
+    expect(events).toHaveLength(1) // only one PeerFound
+  })
+
+  it('should emit PeerUpdated when name changes', () => {
+    service.simulatePeerPing({ id: 'peer-1', name: 'Old Name', ipAddress: '192.168.1.101', port: 9876 })
+    service.simulatePeerPing({ id: 'peer-1', name: 'New Name', ipAddress: '192.168.1.101', port: 9876 })
+    expect(events).toHaveLength(2)
+    expect(events[1].event).toBe(DiscoveryEvent.PeerUpdated)
+    expect(events[1].peer.name).toBe('New Name')
+  })
+
+  it('should emit PeerLost on explicit offline', () => {
+    service.simulatePeerPing({ id: 'peer-1', name: 'Peer', ipAddress: '192.168.1.101', port: 9876 })
+    service.simulatePeerOffline('peer-1')
+    expect(events).toHaveLength(2)
+    expect(events[1].event).toBe(DiscoveryEvent.PeerLost)
+    expect(service.getPeers()).toHaveLength(0)
+  })
+
+  it('should emit PeerLost on timeout', () => {
+    service.simulatePeerPing({ id: 'peer-1', name: 'Peer', ipAddress: '192.168.1.101', port: 9876 })
+    service.simulateTimeout('peer-1')
+    expect(events).toHaveLength(2)
+    expect(events[1].event).toBe(DiscoveryEvent.PeerLost)
+    expect(service.getPeers()).toHaveLength(0)
+  })
+
+  it('should track multiple peers', () => {
+    service.simulatePeerPing({ id: 'peer-1', name: 'Peer 1', ipAddress: '192.168.1.101', port: 9876 })
+    service.simulatePeerPing({ id: 'peer-2', name: 'Peer 2', ipAddress: '192.168.1.102', port: 9876 })
+    expect(service.getPeers()).toHaveLength(2)
+  })
+
+  it('should remove handler with off()', () => {
+    service.off(handler)
+    service.simulatePeerPing({ id: 'peer-1', name: 'Peer', ipAddress: '192.168.1.101', port: 9876 })
+    expect(events).toHaveLength(0)
+  })
+
+  it('should update lastSeen on heartbeat', async () => {
+    service.simulatePeerPing({ id: 'peer-1', name: 'Peer', ipAddress: '192.168.1.101', port: 9876 })
+    const firstSeen = service.getPeers()[0].lastSeen
+    // Wait a tiny bit for Date.now() to advance
+    await new Promise((r) => setTimeout(r, 5))
+    service.simulatePeerPing({ id: 'peer-1', name: 'Peer', ipAddress: '192.168.1.101', port: 9876 })
+    const secondSeen = service.getPeers()[0].lastSeen
+    expect(secondSeen).toBeGreaterThanOrEqual(firstSeen)
+  })
+})

--- a/frontend/src/discovery/index.ts
+++ b/frontend/src/discovery/index.ts
@@ -1,0 +1,3 @@
+export { DiscoveryEvent, DEFAULT_CONFIG } from './types'
+export type { Peer, DiscoveryConfig, DiscoveryService, DiscoveryEventHandler } from './types'
+export { MockDiscoveryService } from './mock'

--- a/frontend/src/discovery/mock.ts
+++ b/frontend/src/discovery/mock.ts
@@ -1,0 +1,118 @@
+/**
+ * Discovery Service - In-Memory Implementation
+ *
+ * Simulates UDP discovery for unit testing.
+ * Production uses Tauri backend (Rust UDP sockets).
+ */
+
+import type { Peer, DiscoveryConfig, DiscoveryService, DiscoveryEventHandler } from './types'
+import { DiscoveryEvent, DEFAULT_CONFIG } from './types'
+
+export class MockDiscoveryService implements DiscoveryService {
+  private peers = new Map<string, Peer>()
+  private handlers: DiscoveryEventHandler[] = []
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private timeoutTimer: ReturnType<typeof setInterval> | null = null
+  private config: DiscoveryConfig
+  private running = false
+
+  constructor(config: Partial<DiscoveryConfig> & Pick<DiscoveryConfig, 'deviceId' | 'deviceName' | 'servicePort'>) {
+    this.config = { ...DEFAULT_CONFIG, ...config }
+  }
+
+  get isRunning(): boolean {
+    return this.running
+  }
+
+  start(): void {
+    if (this.running) return
+    this.running = true
+
+    // Start timeout checker
+    this.timeoutTimer = setInterval(() => {
+      this.checkTimeouts()
+    }, this.config.heartbeatInterval)
+  }
+
+  stop(): void {
+    if (!this.running) return
+    this.running = false
+
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+    if (this.timeoutTimer) {
+      clearInterval(this.timeoutTimer)
+      this.timeoutTimer = null
+    }
+  }
+
+  getPeers(): Peer[] {
+    return Array.from(this.peers.values())
+  }
+
+  on(handler: DiscoveryEventHandler): void {
+    this.handlers.push(handler)
+  }
+
+  off(handler: DiscoveryEventHandler): void {
+    const idx = this.handlers.indexOf(handler)
+    if (idx !== -1) this.handlers.splice(idx, 1)
+  }
+
+  // --- Test helpers ---
+
+  /** Simulate receiving a ping from a peer */
+  simulatePeerPing(peer: Omit<Peer, 'lastSeen'>): void {
+    const now = Date.now()
+    const existing = this.peers.get(peer.id)
+    const fullPeer: Peer = { ...peer, lastSeen: now }
+
+    if (!existing) {
+      this.peers.set(peer.id, fullPeer)
+      this.emit(DiscoveryEvent.PeerFound, fullPeer)
+    } else {
+      const updated = existing.name !== peer.name || existing.port !== peer.port
+      this.peers.set(peer.id, fullPeer)
+      if (updated) {
+        this.emit(DiscoveryEvent.PeerUpdated, fullPeer)
+      }
+    }
+  }
+
+  /** Simulate a peer going offline explicitly */
+  simulatePeerOffline(peerId: string): void {
+    const peer = this.peers.get(peerId)
+    if (peer) {
+      this.peers.delete(peerId)
+      this.emit(DiscoveryEvent.PeerLost, peer)
+    }
+  }
+
+  /** Simulate time passing to trigger timeouts */
+  simulateTimeout(peerId: string): void {
+    const peer = this.peers.get(peerId)
+    if (peer) {
+      // Set lastSeen to beyond threshold
+      peer.lastSeen = Date.now() - this.config.timeoutThreshold - 1
+      this.checkTimeouts()
+    }
+  }
+
+  private checkTimeouts(): void {
+    const now = Date.now()
+    for (const [id, peer] of this.peers) {
+      if (now - peer.lastSeen > this.config.timeoutThreshold) {
+        this.peers.delete(id)
+        this.emit(DiscoveryEvent.PeerLost, peer)
+      }
+    }
+  }
+
+  private emit(event: DiscoveryEvent, peer: Peer): void {
+    for (const handler of this.handlers) {
+      handler(event, peer)
+    }
+  }
+}

--- a/frontend/src/discovery/types.ts
+++ b/frontend/src/discovery/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Discovery Service - Types and Interfaces
+ *
+ * UDP broadcast-based device discovery for LAN.
+ * Heartbeat: every 30s. Timeout: 90s without heartbeat = offline.
+ */
+
+/** Discovered peer device */
+export interface Peer {
+  /** Device UUID */
+  id: string
+  /** Display name */
+  name: string
+  /** IP address */
+  ipAddress: string
+  /** Service port */
+  port: number
+  /** Last heartbeat received (Unix ms) */
+  lastSeen: number
+}
+
+/** Discovery events */
+export enum DiscoveryEvent {
+  /** New peer discovered */
+  PeerFound = 'peer-found',
+  /** Peer went offline (timeout or explicit) */
+  PeerLost = 'peer-lost',
+  /** Peer info updated (name, port change) */
+  PeerUpdated = 'peer-updated',
+}
+
+export type DiscoveryEventHandler = (event: DiscoveryEvent, peer: Peer) => void
+
+/** Discovery service configuration */
+export interface DiscoveryConfig {
+  /** Broadcast port (default: 19876) */
+  broadcastPort: number
+  /** Heartbeat interval in ms (default: 30000) */
+  heartbeatInterval: number
+  /** Timeout threshold in ms (default: 90000) */
+  timeoutThreshold: number
+  /** This device's ID */
+  deviceId: string
+  /** This device's display name */
+  deviceName: string
+  /** This device's service port */
+  servicePort: number
+}
+
+export const DEFAULT_CONFIG: Omit<DiscoveryConfig, 'deviceId' | 'deviceName' | 'servicePort'> = {
+  broadcastPort: 19876,
+  heartbeatInterval: 30_000,
+  timeoutThreshold: 90_000,
+}
+
+/** Discovery service interface */
+export interface DiscoveryService {
+  /** Start broadcasting and listening */
+  start(): void
+  /** Stop the service and broadcast offline */
+  stop(): void
+  /** Get currently known peers */
+  getPeers(): Peer[]
+  /** Register event handler */
+  on(handler: DiscoveryEventHandler): void
+  /** Remove event handler */
+  off(handler: DiscoveryEventHandler): void
+  /** Whether service is running */
+  readonly isRunning: boolean
+}


### PR DESCRIPTION
## What

UDP broadcast-based device discovery with heartbeat and timeout.

## Changes

- TypeScript: types, interfaces, mock implementation
- Rust: UDP broadcast/listen, heartbeat 30s, timeout 90s
- Event-driven: PeerFound / PeerUpdated / PeerLost
- 9 unit tests passing

## How to test

```bash
cd frontend
npm run test
```

Closes #4