### PR TITLE
feat(T5): 消息收发服务 — TCP message send/receive

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -27,3 +27,8 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 rmp-serde = "1"
+tokio = { version = "1", features = ["full"] }
+sha2 = "0.10"
+anyhow = "1"
+serde_bytes = "0.11"
+hostname = "0.4"

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -1,11 +1,14 @@
 use tauri::{command, AppHandle, Emitter};
 use serde::{Deserialize, Serialize};
 
+use crate::device::DeviceConfig;
 use crate::storage::{Database, Contact, StoredMessage, FileTransfer};
 use crate::discovery::DiscoveryService;
+use crate::messenger::MessengerHandle;
+use crate::protocol::types::{MessageType, TextMessage as ProtoTextMessage};
 
 // ============================================================
-// IPC Commands - invoked from frontend via `invoke()`
+// IPC Commands
 // ============================================================
 
 // --- Contacts ---
@@ -39,12 +42,8 @@ pub async fn get_messages(
     offset: Option<i64>,
     db: tauri::State<'_, Database>,
 ) -> Result<Vec<StoredMessage>, String> {
-    db.query_messages(
-        contact_id.as_deref(),
-        limit.unwrap_or(50),
-        offset.unwrap_or(0),
-    )
-    .map_err(|e| e.to_string())
+    db.query_messages(contact_id.as_deref(), limit.unwrap_or(50), offset.unwrap_or(0))
+        .map_err(|e| e.to_string())
 }
 
 #[command]
@@ -78,11 +77,11 @@ pub async fn send_message(
     request: SendMessageRequest,
     app: AppHandle,
     db: tauri::State<'_, Database>,
+    device: tauri::State<'_, DeviceConfig>,
 ) -> Result<StoredMessage, String> {
-    // Create message record
     let msg = StoredMessage {
         id: uuid::Uuid::new_v4().to_string(),
-        sender_id: "self".to_string(), // Will be replaced with actual device ID
+        sender_id: device.device_id.clone(),
         recipient_id: request.recipient_id,
         content: request.content,
         timestamp: chrono::Utc::now().timestamp_millis(),
@@ -92,13 +91,30 @@ pub async fn send_message(
 
     db.insert_message(&msg).map_err(|e| e.to_string())?;
 
-    // TODO: Actually send via network (T5/T6 dependency)
-    // For now, just mark as sent
+    // Look up recipient to get their IP and port
+    let contact = db.get_contact(&msg.recipient_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Contact {} not found", msg.recipient_id))?;
+
+    let proto_msg = ProtoTextMessage {
+        msg_type: MessageType::TextMsg as u8,
+        msg_id: msg.id.clone(),
+        from_id: device.device_id.clone(),
+        timestamp: msg.timestamp as u64,
+        content: msg.content.clone(),
+    };
+
+    let peer_addr = format!("{}:{}", contact.ip_address, contact.port)
+        .parse()
+        .map_err(|e: std::net::AddrParseError| e.to_string())?;
+
+    let messenger = app.state::<MessengerHandle>();
+    messenger.send_message(peer_addr, proto_msg)
+        .await
+        .map_err(|e| e.to_string())?;
+
     db.update_message_status(&msg.id, "sent").map_err(|e| e.to_string())?;
-
-    // Emit event to frontend
     let _ = app.emit("message-sent", &msg);
-
     Ok(msg)
 }
 
@@ -106,19 +122,16 @@ pub async fn send_message(
 
 #[command]
 pub async fn start_discovery() -> Result<(), String> {
-    // Managed by app state, started on app init
     Ok(())
 }
 
 #[command]
 pub async fn stop_discovery() -> Result<(), String> {
-    // Managed by app state, stopped on app close
     Ok(())
 }
 
 #[command]
 pub async fn get_discovered_peers() -> Result<Vec<PeerResponse>, String> {
-    // TODO: Get from discovery service state
     Ok(vec![])
 }
 
@@ -143,7 +156,7 @@ pub async fn initiate_file_transfer(
     request: FileTransferRequest,
     app: AppHandle,
 ) -> Result<String, String> {
-    // TODO: Implement file transfer initiation (T5/T6)
+    // TODO: Wire to FileTransferHandle (T6)
     let transfer_id = uuid::Uuid::new_v4().to_string();
     let _ = app.emit("file-transfer-initiated", &transfer_id);
     Ok(transfer_id)
@@ -151,7 +164,6 @@ pub async fn initiate_file_transfer(
 
 #[command]
 pub async fn accept_file_transfer(transfer_id: String, app: AppHandle) -> Result<(), String> {
-    // TODO: Accept incoming file transfer
     let _ = app.emit("file-transfer-accepted", &transfer_id);
     Ok(())
 }
@@ -160,33 +172,4 @@ pub async fn accept_file_transfer(transfer_id: String, app: AppHandle) -> Result
 pub async fn reject_file_transfer(transfer_id: String, app: AppHandle) -> Result<(), String> {
     let _ = app.emit("file-transfer-rejected", &transfer_id);
     Ok(())
-}
-
-// ============================================================
-// Events - emitted from backend to frontend
-// ============================================================
-// Event names (constants for consistency):
-// - "message-received"     — new incoming message
-// - "message-sent"         — message successfully sent
-// - "peer-found"           — new device discovered
-// - "peer-lost"            — device went offline
-// - "peer-updated"         — device info changed
-// - "file-transfer-progress" — transfer progress update
-// - "file-transfer-complete" — transfer finished
-// - "file-transfer-initiated" — outgoing transfer started
-// - "file-transfer-accepted" — incoming transfer accepted
-// - "file-transfer-rejected" — incoming transfer rejected
-
-/// Register all IPC commands with the Tauri builder.
-/// Call this in lib.rs: `.invoke_handler(tauri::generate_handler![...])`
-pub fn get_handlers() -> Vec<&'static str> {
-    // This is just documentation; actual registration uses the macro:
-    // tauri::generate_handler![
-    //   get_contacts, get_online_contacts, get_contact, delete_contact,
-    //   get_messages, get_message, delete_message, delete_messages_by_contact,
-    //   send_message,
-    //   start_discovery, stop_discovery, get_discovered_peers,
-    //   initiate_file_transfer, accept_file_transfer, reject_file_transfer,
-    // ]
-    vec![]
 }

--- a/frontend/src-tauri/src/device.rs
+++ b/frontend/src-tauri/src/device.rs
@@ -1,0 +1,5 @@
+/// Shared device configuration, managed as Tauri state.
+pub struct DeviceConfig {
+    pub device_id: String,
+    pub device_name: String,
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,9 +1,15 @@
 mod commands;
+mod device;
 mod discovery;
+mod messenger;
+mod protocol;
 mod storage;
 
+use device::DeviceConfig;
+use messenger::MessengerService;
 use storage::Database;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -27,6 +33,65 @@ pub fn run() {
             let db = Database::open(&db_path)
                 .expect("Failed to open database");
             app.manage(db);
+
+            // Generate or load device ID
+            let messenger_db = Arc::new(Database::open(&db_path)
+                .expect("Failed to open database for messenger"));
+
+            let device_id = {
+                let db_ref = messenger_db.as_ref();
+                match db_ref.get_config("device_id") {
+                    Ok(Some(id)) => id,
+                    _ => {
+                        let id = uuid::Uuid::new_v4().to_string();
+                        let _ = db_ref.set_config("device_id", &id);
+                        id
+                    }
+                }
+            };
+            let device_name = {
+                let db_ref = messenger_db.as_ref();
+                match db_ref.get_config("device_name") {
+                    Ok(Some(name)) => name,
+                    _ => {
+                        let name = hostname::get()
+                            .map(|h| h.to_string_lossy().to_string())
+                            .unwrap_or_else(|_| "LAN Messenger".to_string());
+                        let _ = db_ref.set_config("device_name", &name);
+                        name
+                    }
+                }
+            };
+
+            app.manage(DeviceConfig {
+                device_id: device_id.clone(),
+                device_name: device_name.clone(),
+            });
+
+            // Start messenger service
+            let mut messenger_svc = MessengerService::new(
+                messenger::service::MSG_PORT,
+                messenger_db,
+            );
+
+            let app_handle = app.handle().clone();
+            let dev_id = device_id.clone();
+            messenger_svc.on_message(move |msg| {
+                use tauri::Emitter;
+                let _ = app_handle.emit("message-received", &storage::StoredMessage {
+                    id: msg.msg_id.clone(),
+                    sender_id: msg.from_id.clone(),
+                    recipient_id: dev_id.clone(),
+                    content: msg.content.clone(),
+                    timestamp: msg.timestamp as i64,
+                    status: "received".to_string(),
+                    file_transfer_id: None,
+                });
+            });
+
+            let handle = tauri::async_runtime::block_on(messenger_svc.start())
+                .expect("Failed to start messenger service");
+            app.manage(handle);
 
             Ok(())
         })

--- a/frontend/src-tauri/src/messenger/mod.rs
+++ b/frontend/src-tauri/src/messenger/mod.rs
@@ -1,0 +1,3 @@
+pub mod service;
+
+pub use service::{MessengerService, MessengerHandle};

--- a/frontend/src-tauri/src/messenger/service.rs
+++ b/frontend/src-tauri/src/messenger/service.rs
@@ -1,0 +1,210 @@
+use anyhow::{Context, Result};
+use log::{error, info, warn};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+
+use crate::protocol::codec::FrameCodec;
+use crate::protocol::types::{MessageType, TextAck, TextMessage};
+use crate::storage::db::Database;
+
+/// Default TCP port for messaging.
+pub const MSG_PORT: u16 = 2426;
+
+/// Callback type for incoming messages.
+pub type OnMessageReceived = Arc<dyn Fn(TextMessage) + Send + Sync>;
+
+/// Messenger service: TCP listener + send API.
+pub struct MessengerService {
+    port: u16,
+    db: Arc<Database>,
+    on_message: Option<OnMessageReceived>,
+}
+
+/// Handle for sending messages and shutting down.
+pub struct MessengerHandle {
+    outbound_tx: mpsc::Sender<(SocketAddr, TextMessage)>,
+    cancel: tokio::sync::watch::Sender<bool>,
+}
+
+impl MessengerHandle {
+    /// Send a text message to a peer via short-lived TCP connection.
+    pub async fn send_message(&self, peer_addr: SocketAddr, msg: TextMessage) -> Result<()> {
+        self.outbound_tx
+            .send((peer_addr, msg))
+            .await
+            .context("Outbound channel closed")?;
+        Ok(())
+    }
+
+    pub fn shutdown(&self) {
+        let _ = self.cancel.send(true);
+    }
+}
+
+impl MessengerService {
+    pub fn new(port: u16, db: Arc<Database>) -> Self {
+        Self { port, db, on_message: None }
+    }
+
+    pub fn on_message<F: Fn(TextMessage) + Send + Sync + 'static>(&mut self, f: F) {
+        self.on_message = Some(Arc::new(f));
+    }
+
+    pub async fn start(self) -> Result<MessengerHandle> {
+        let addr = format!("0.0.0.0:{}", self.port);
+        let listener = TcpListener::bind(&addr)
+            .await
+            .with_context(|| format!("Failed to bind TCP on {}", addr))?;
+        info!("Messenger listening on {}", addr);
+
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let (outbound_tx, mut outbound_rx) = mpsc::channel::<(SocketAddr, TextMessage)>(256);
+
+        let db = self.db.clone();
+        let on_message = self.on_message.clone();
+
+        // Listener task
+        let mut cancel_rx_l = cancel_rx.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_rx_l.changed() => { info!("Messenger shutting down"); break; }
+                    res = listener.accept() => {
+                        match res {
+                            Ok((stream, peer)) => {
+                                let db = db.clone();
+                                let cb = on_message.clone();
+                                tokio::spawn(async move {
+                                    if let Err(e) = handle_incoming(stream, peer, db, cb).await {
+                                        warn!("Incoming msg from {} error: {}", peer, e);
+                                    }
+                                });
+                            }
+                            Err(e) => error!("Accept error: {}", e),
+                        }
+                    }
+                }
+            }
+        });
+
+        // Outbound task
+        let mut cancel_rx_o = cancel_rx.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_rx_o.changed() => break,
+                    Some((peer, msg)) = outbound_rx.recv() => {
+                        tokio::spawn(async move {
+                            if let Err(e) = send_to_peer(peer, &msg).await {
+                                error!("Send to {} failed: {}", peer, e);
+                            }
+                        });
+                    }
+                    else => break,
+                }
+            }
+        });
+
+        Ok(MessengerHandle { outbound_tx, cancel: cancel_tx })
+    }
+}
+
+/// Handle incoming: read TextMsg → store → ACK → callback.
+async fn handle_incoming(
+    mut stream: TcpStream,
+    peer: SocketAddr,
+    db: Arc<Database>,
+    on_message: Option<OnMessageReceived>,
+) -> Result<()> {
+    let msg: TextMessage = FrameCodec::read_frame(&mut stream).await?;
+    if msg.msg_type != MessageType::TextMsg as u8 {
+        warn!("Unexpected msg_type {} from {}", msg.msg_type, peer);
+        return Ok(());
+    }
+
+    info!("Received message {} from {}", msg.msg_id, peer);
+
+    let stored = crate::storage::db::StoredMessage {
+        id: msg.msg_id.clone(),
+        sender_id: msg.from_id.clone(),
+        recipient_id: "self".to_string(),
+        content: msg.content.clone(),
+        timestamp: msg.timestamp as i64,
+        status: "received".to_string(),
+        file_transfer_id: None,
+    };
+    if let Err(e) = db.insert_message(&stored) {
+        error!("Failed to store message: {}", e);
+    }
+
+    let ack = TextAck {
+        msg_type: MessageType::TextAck as u8,
+        msg_id: msg.msg_id.clone(),
+        status: "received".to_string(),
+    };
+    FrameCodec::write_frame(&mut stream, &ack).await?;
+
+    if let Some(cb) = on_message { cb(msg); }
+    Ok(())
+}
+
+/// Send TextMessage via short-lived TCP connection.
+async fn send_to_peer(peer_addr: SocketAddr, msg: &TextMessage) -> Result<()> {
+    let mut stream = TcpStream::connect(peer_addr)
+        .await
+        .with_context(|| format!("Connect to {} failed", peer_addr))?;
+
+    FrameCodec::write_frame(&mut stream, msg).await?;
+
+    let ack: TextAck = FrameCodec::read_frame(&mut stream).await?;
+    if ack.msg_id != msg.msg_id {
+        warn!("ACK msg_id mismatch: expected {}, got {}", msg.msg_id, ack.msg_id);
+    }
+    info!("Message {} delivered, status: {}", msg.msg_id, ack.status);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_send_receive_message() {
+        let db = Arc::new(Database::open_in_memory().unwrap());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let (msg_tx, mut msg_rx) = mpsc::channel::<TextMessage>(1);
+        let db_recv = db.clone();
+        tokio::spawn(async move {
+            let (stream, peer) = listener.accept().await.unwrap();
+            handle_incoming(stream, peer, db_recv, Some(Arc::new(move |msg| {
+                let _ = msg_tx.try_send(msg);
+            }))).await.unwrap();
+        });
+
+        let msg = TextMessage {
+            msg_type: MessageType::TextMsg as u8,
+            msg_id: "test-msg-001".to_string(),
+            from_id: "sender-1".to_string(),
+            timestamp: 1234567890000,
+            content: "Hello from test!".to_string(),
+        };
+
+        let addr: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
+        send_to_peer(addr, &msg).await.unwrap();
+
+        let received = tokio::time::timeout(
+            std::time::Duration::from_secs(2), msg_rx.recv()
+        ).await.unwrap().unwrap();
+        assert_eq!(received.msg_id, "test-msg-001");
+        assert_eq!(received.content, "Hello from test!");
+
+        let stored = db.get_message("test-msg-001").unwrap().unwrap();
+        assert_eq!(stored.content, "Hello from test!");
+        assert_eq!(stored.status, "received");
+    }
+}

--- a/frontend/src-tauri/src/protocol/codec.rs
+++ b/frontend/src-tauri/src/protocol/codec.rs
@@ -1,0 +1,96 @@
+use anyhow::{bail, Result};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Protocol magic bytes: "LM" (0x4C4D)
+pub const FRAME_MAGIC: [u8; 2] = [0x4C, 0x4D];
+/// Header: 2 (magic) + 4 (length) = 6 bytes
+pub const HEADER_SIZE: usize = 6;
+/// Max payload: 16 MB
+pub const MAX_PAYLOAD_SIZE: u32 = 16 * 1024 * 1024;
+
+pub struct FrameCodec;
+
+impl FrameCodec {
+    /// Encode a message into framed bytes: [magic(2)] [len(4 BE)] [payload]
+    pub fn encode<T: serde::Serialize>(msg: &T) -> Result<Vec<u8>> {
+        let payload = rmp_serde::to_vec(msg)?;
+        let len = payload.len() as u32;
+        if len > MAX_PAYLOAD_SIZE {
+            bail!("Payload size {} exceeds max {}", len, MAX_PAYLOAD_SIZE);
+        }
+        let mut frame = Vec::with_capacity(HEADER_SIZE + payload.len());
+        frame.extend_from_slice(&FRAME_MAGIC);
+        frame.extend_from_slice(&len.to_be_bytes());
+        frame.extend_from_slice(&payload);
+        Ok(frame)
+    }
+
+    /// Read one frame from an async reader.
+    pub async fn read_frame<R: AsyncReadExt + Unpin, T: serde::de::DeserializeOwned>(
+        reader: &mut R,
+    ) -> Result<T> {
+        let mut header = [0u8; HEADER_SIZE];
+        reader.read_exact(&mut header).await?;
+        if header[0] != FRAME_MAGIC[0] || header[1] != FRAME_MAGIC[1] {
+            bail!("Invalid magic: {:02X}{:02X}", header[0], header[1]);
+        }
+        let len = u32::from_be_bytes([header[2], header[3], header[4], header[5]]);
+        if len > MAX_PAYLOAD_SIZE {
+            bail!("Payload length {} exceeds max {}", len, MAX_PAYLOAD_SIZE);
+        }
+        let mut payload = vec![0u8; len as usize];
+        reader.read_exact(&mut payload).await?;
+        Ok(rmp_serde::from_slice(&payload)?)
+    }
+
+    /// Write one frame to an async writer.
+    pub async fn write_frame<W: AsyncWriteExt + Unpin, T: serde::Serialize>(
+        writer: &mut W,
+        msg: &T,
+    ) -> Result<()> {
+        let frame = Self::encode(msg)?;
+        writer.write_all(&frame).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::types::{TextMessage, MessageType};
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let msg = TextMessage {
+            msg_type: MessageType::TextMsg as u8,
+            msg_id: "test-123".to_string(),
+            from_id: "user-1".to_string(),
+            timestamp: 1234567890,
+            content: "Hello, world!".to_string(),
+        };
+        let frame = FrameCodec::encode(&msg).unwrap();
+        assert_eq!(&frame[0..2], &FRAME_MAGIC);
+        let len = u32::from_be_bytes([frame[2], frame[3], frame[4], frame[5]]);
+        assert_eq!(len as usize, frame.len() - HEADER_SIZE);
+        let decoded: TextMessage = rmp_serde::from_slice(&frame[HEADER_SIZE..]).unwrap();
+        assert_eq!(decoded.msg_id, "test-123");
+        assert_eq!(decoded.content, "Hello, world!");
+    }
+
+    #[tokio::test]
+    async fn test_async_read_write_frame() {
+        let msg = TextMessage {
+            msg_type: MessageType::TextMsg as u8,
+            msg_id: "async-test".to_string(),
+            from_id: "user-2".to_string(),
+            timestamp: 9999,
+            content: "Async!".to_string(),
+        };
+        let mut buf = Vec::new();
+        FrameCodec::write_frame(&mut buf, &msg).await.unwrap();
+        let mut cursor = std::io::Cursor::new(buf);
+        let decoded: TextMessage = FrameCodec::read_frame(&mut cursor).await.unwrap();
+        assert_eq!(decoded.msg_id, "async-test");
+    }
+}

--- a/frontend/src-tauri/src/protocol/mod.rs
+++ b/frontend/src-tauri/src/protocol/mod.rs
@@ -1,0 +1,5 @@
+pub mod codec;
+pub mod types;
+
+pub use codec::{FrameCodec, FRAME_MAGIC, HEADER_SIZE, MAX_PAYLOAD_SIZE};
+pub use types::*;

--- a/frontend/src-tauri/src/protocol/types.rs
+++ b/frontend/src-tauri/src/protocol/types.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+
+/// Message type identifiers matching the protocol spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum MessageType {
+    // Discovery (UDP)
+    Online = 0x01,
+    Offline = 0x02,
+    Heartbeat = 0x03,
+    // Instant messaging (TCP:2426)
+    TextMsg = 0x10,
+    TextAck = 0x11,
+    // File transfer (TCP:2427)
+    FileReq = 0x20,
+    FileAccept = 0x21,
+    FileReject = 0x22,
+    FileData = 0x23,
+    FileAck = 0x24,
+    FileDone = 0x25,
+    FileCancel = 0x26,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextMessage {
+    pub msg_type: u8,
+    pub msg_id: String,
+    pub from_id: String,
+    pub timestamp: u64,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextAck {
+    pub msg_type: u8,
+    pub msg_id: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileRequest {
+    pub msg_type: u8,
+    pub transfer_id: String,
+    pub from_id: String,
+    pub filename: String,
+    pub file_size: u64,
+    pub checksum: String,
+    pub chunk_size: u32,
+    pub resume_from_seq: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileResponse {
+    pub msg_type: u8,
+    pub transfer_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileData {
+    pub msg_type: u8,
+    pub transfer_id: String,
+    pub seq: u32,
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileChunkAck {
+    pub msg_type: u8,
+    pub transfer_id: String,
+    pub seq: u32,
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileDone {
+    pub msg_type: u8,
+    pub transfer_id: String,
+    pub checksum: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileCancel {
+    pub msg_type: u8,
+    pub transfer_id: String,
+    pub reason: Option<String>,
+}

--- a/frontend/src-tauri/src/storage/db.rs
+++ b/frontend/src-tauri/src/storage/db.rs
@@ -322,4 +322,23 @@ impl Database {
             None => Ok(None),
         }
     }
+
+    // --- Config ---
+
+    pub fn get_config(&self, key: &str) -> Result<Option<String>> {
+        let mut stmt = self.conn.prepare("SELECT value FROM config WHERE key = ?1")?;
+        let mut rows = stmt.query_map(params![key], |row| row.get(0))?;
+        match rows.next() {
+            Some(row) => Ok(Some(row?)),
+            None => Ok(None),
+        }
+    }
+
+    pub fn set_config(&self, key: &str, value: &str) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO config (key, value) VALUES (?1, ?2) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![key, value],
+        )?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
## 改了什么
- **protocol 模块 (Rust)**：帧编解码器（Magic 0x4C4D + Length + MessagePack），完整消息类型定义
- **messenger 模块**：TCP 监听器，短连接收发，ACK 处理，incoming message 回调
- **IPC 集成**：`send_message` command 现在通过网络实际发送，不再是 TODO stub
- **依赖补全**：tokio, uuid, chrono, rusqlite(bundled), rmp-serde, sha2, anyhow, serde_bytes

## 为什么改
T5 任务：实现 messenger/ 模块的 TCP 消息收发功能。

## 设计要点
- **短连接模式**：每条消息 connect → send → ack → close（ADR-002）
- **帧格式**：`[0x4C4D][len:4B BE][MessagePack payload]`，与前端 codec 对齐
- **异步架构**：tokio listener + spawned connection handlers + mpsc outbound channel
- **存储集成**：收到消息自动写入 SQLite，通过 Tauri event 推送前端

## 怎么测
- `cargo test` 跑 protocol codec roundtrip 和 messenger send/receive 集成测试
- 两个节点间 TCP 消息互发，验证 ACK 返回和 DB 存储

## 关联
Closes #6