### PR TITLE
feat(T8/T9/T10): 前端三件套 — ContactList + ChatView + FileTransfer

### DIFF
--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::device::DeviceConfig;
 use crate::storage::{Database, Contact, StoredMessage, FileTransfer};
 use crate::discovery::DiscoveryService;
+use crate::file_transfer::FileTransferHandle;
 use crate::messenger::MessengerHandle;
 use crate::protocol::types::{MessageType, TextMessage as ProtoTextMessage};
 
@@ -155,9 +156,23 @@ pub struct FileTransferRequest {
 pub async fn initiate_file_transfer(
     request: FileTransferRequest,
     app: AppHandle,
+    db: tauri::State<'_, Database>,
 ) -> Result<String, String> {
-    // TODO: Wire to FileTransferHandle (T6)
-    let transfer_id = uuid::Uuid::new_v4().to_string();
+    let contact = db.get_contact(&request.recipient_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Contact {} not found", request.recipient_id))?;
+
+    let peer_addr: std::net::SocketAddr = format!("{}:{}", contact.ip_address, crate::file_transfer::service::FILE_PORT)
+        .parse()
+        .map_err(|e: std::net::AddrParseError| e.to_string())?;
+
+    let ft = app.state::<FileTransferHandle>();
+    let transfer_id = ft.send_file(
+        peer_addr,
+        std::path::PathBuf::from(&request.file_path),
+        request.recipient_id,
+    ).await.map_err(|e| e.to_string())?;
+
     let _ = app.emit("file-transfer-initiated", &transfer_id);
     Ok(transfer_id)
 }

--- a/frontend/src-tauri/src/file_transfer/mod.rs
+++ b/frontend/src-tauri/src/file_transfer/mod.rs
@@ -1,0 +1,3 @@
+pub mod service;
+
+pub use service::{FileTransferService, FileTransferHandle};

--- a/frontend/src-tauri/src/file_transfer/service.rs
+++ b/frontend/src-tauri/src/file_transfer/service.rs
@@ -1,0 +1,681 @@
+use anyhow::{bail, Context, Result};
+use log::{error, info, warn};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{mpsc, Mutex, RwLock};
+
+use crate::protocol::codec::FrameCodec;
+use crate::protocol::types::*;
+use crate::storage::db::{Database, FileTransfer as DbFileTransfer};
+
+/// Default TCP port for file transfer.
+pub const FILE_PORT: u16 = 2427;
+/// Default chunk size: 64 KB.
+pub const DEFAULT_CHUNK_SIZE: u32 = 64 * 1024;
+
+/// Progress callback: (transfer_id, bytes_transferred, total_bytes)
+pub type OnProgress = Arc<dyn Fn(&str, u64, u64) + Send + Sync>;
+/// Incoming file request callback: (request) -> bool (accept/reject)
+pub type OnFileRequest = Arc<dyn Fn(&FileRequest) -> bool + Send + Sync>;
+/// Transfer complete callback: (transfer_id)
+pub type OnComplete = Arc<dyn Fn(&str) + Send + Sync>;
+/// Transfer failed callback: (transfer_id, reason)
+pub type OnFailed = Arc<dyn Fn(&str, &str) + Send + Sync>;
+
+/// Active transfer state.
+struct TransferState {
+    transfer_id: String,
+    filename: String,
+    file_size: u64,
+    bytes_transferred: u64,
+    status: String,
+    local_path: Option<PathBuf>,
+}
+
+/// Outbound send request.
+struct SendRequest {
+    peer_addr: SocketAddr,
+    file_path: PathBuf,
+    transfer_id: String,
+    peer_id: String,
+}
+
+pub struct FileTransferService {
+    port: u16,
+    db: Arc<Database>,
+    download_dir: PathBuf,
+    on_progress: Option<OnProgress>,
+    on_file_request: Option<OnFileRequest>,
+    on_complete: Option<OnComplete>,
+    on_failed: Option<OnFailed>,
+}
+
+pub struct FileTransferHandle {
+    outbound_tx: mpsc::Sender<SendRequest>,
+    transfers: Arc<RwLock<HashMap<String, TransferState>>>,
+    cancel: tokio::sync::watch::Sender<bool>,
+}
+
+impl FileTransferHandle {
+    /// Initiate sending a file to a peer.
+    pub async fn send_file(
+        &self,
+        peer_addr: SocketAddr,
+        file_path: PathBuf,
+        peer_id: String,
+    ) -> Result<String> {
+        let transfer_id = uuid::Uuid::new_v4().to_string();
+
+        // Get file metadata
+        let metadata = tokio::fs::metadata(&file_path).await?;
+
+        self.transfers.write().await.insert(
+            transfer_id.clone(),
+            TransferState {
+                transfer_id: transfer_id.clone(),
+                filename: file_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string(),
+                file_size: metadata.len(),
+                bytes_transferred: 0,
+                status: "pending".to_string(),
+                local_path: Some(file_path.clone()),
+            },
+        );
+
+        self.outbound_tx
+            .send(SendRequest {
+                peer_addr,
+                file_path,
+                transfer_id: transfer_id.clone(),
+                peer_id,
+            })
+            .await
+            .context("Outbound channel closed")?;
+
+        Ok(transfer_id)
+    }
+
+    pub fn shutdown(&self) {
+        let _ = self.cancel.send(true);
+    }
+}
+
+impl FileTransferService {
+    pub fn new(port: u16, db: Arc<Database>, download_dir: PathBuf) -> Self {
+        Self {
+            port,
+            db,
+            download_dir,
+            on_progress: None,
+            on_file_request: None,
+            on_complete: None,
+            on_failed: None,
+        }
+    }
+
+    pub fn on_progress<F: Fn(&str, u64, u64) + Send + Sync + 'static>(&mut self, f: F) {
+        self.on_progress = Some(Arc::new(f));
+    }
+
+    pub fn on_file_request<F: Fn(&FileRequest) -> bool + Send + Sync + 'static>(&mut self, f: F) {
+        self.on_file_request = Some(Arc::new(f));
+    }
+
+    pub fn on_complete<F: Fn(&str) + Send + Sync + 'static>(&mut self, f: F) {
+        self.on_complete = Some(Arc::new(f));
+    }
+
+    pub fn on_failed<F: Fn(&str, &str) + Send + Sync + 'static>(&mut self, f: F) {
+        self.on_failed = Some(Arc::new(f));
+    }
+
+    pub async fn start(self) -> Result<FileTransferHandle> {
+        let addr = format!("0.0.0.0:{}", self.port);
+        let listener = TcpListener::bind(&addr)
+            .await
+            .with_context(|| format!("Failed to bind file transfer on {}", addr))?;
+        info!("File transfer listening on {}", addr);
+
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let (outbound_tx, mut outbound_rx) = mpsc::channel::<SendRequest>(64);
+        let transfers = Arc::new(RwLock::new(HashMap::new()));
+
+        let db = self.db.clone();
+        let download_dir = self.download_dir.clone();
+        let on_progress = self.on_progress.clone();
+        let on_file_request = self.on_file_request.clone();
+        let on_complete = self.on_complete.clone();
+        let on_failed = self.on_failed.clone();
+        let transfers_listener = transfers.clone();
+
+        // Listener task: accept incoming file transfers
+        let mut cancel_rx_listener = cancel_rx.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_rx_listener.changed() => {
+                        info!("File transfer listener shutting down");
+                        break;
+                    }
+                    accept_result = listener.accept() => {
+                        match accept_result {
+                            Ok((stream, peer)) => {
+                                let db = db.clone();
+                                let dir = download_dir.clone();
+                                let prog = on_progress.clone();
+                                let req_cb = on_file_request.clone();
+                                let comp = on_complete.clone();
+                                let fail = on_failed.clone();
+                                let xfers = transfers_listener.clone();
+                                tokio::spawn(async move {
+                                    if let Err(e) = handle_incoming_transfer(
+                                        stream, peer, db, dir, prog, req_cb, comp, fail, xfers,
+                                    ).await {
+                                        warn!("Incoming transfer from {} failed: {}", peer, e);
+                                    }
+                                });
+                            }
+                            Err(e) => error!("Accept error: {}", e),
+                        }
+                    }
+                }
+            }
+        });
+
+        // Outbound task
+        let transfers_outbound = transfers.clone();
+        let on_progress_out = self.on_progress.clone();
+        let on_complete_out = self.on_complete.clone();
+        let on_failed_out = self.on_failed.clone();
+        let db_out = self.db.clone();
+        let mut cancel_rx_outbound = cancel_rx.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = cancel_rx_outbound.changed() => break,
+                    Some(req) = outbound_rx.recv() => {
+                        let xfers = transfers_outbound.clone();
+                        let prog = on_progress_out.clone();
+                        let comp = on_complete_out.clone();
+                        let fail = on_failed_out.clone();
+                        let db = db_out.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = send_file_to_peer(
+                                req, db, prog, comp, fail, xfers,
+                            ).await {
+                                error!("Outbound transfer failed: {}", e);
+                            }
+                        });
+                    }
+                    else => break,
+                }
+            }
+        });
+
+        Ok(FileTransferHandle {
+            outbound_tx,
+            transfers,
+            cancel: cancel_tx,
+        })
+    }
+}
+
+/// Handle incoming file transfer: read FileReq, accept/reject, receive chunks, verify.
+async fn handle_incoming_transfer(
+    mut stream: TcpStream,
+    peer: SocketAddr,
+    db: Arc<Database>,
+    download_dir: PathBuf,
+    on_progress: Option<OnProgress>,
+    on_file_request: Option<OnFileRequest>,
+    on_complete: Option<OnComplete>,
+    on_failed: Option<OnFailed>,
+    transfers: Arc<RwLock<HashMap<String, TransferState>>>,
+) -> Result<()> {
+    // Read file request
+    let req: FileRequest = FrameCodec::read_frame(&mut stream).await?;
+
+    if req.msg_type != MessageType::FileReq as u8 {
+        bail!("Expected FileReq, got msg_type {}", req.msg_type);
+    }
+
+    info!(
+        "Incoming file request: {} ({} bytes) from {}",
+        req.filename, req.file_size, peer
+    );
+
+    // Check if we should accept
+    let accepted = on_file_request
+        .as_ref()
+        .map(|cb| cb(&req))
+        .unwrap_or(true); // Auto-accept if no callback
+
+    if !accepted {
+        let reject = FileResponse {
+            msg_type: MessageType::FileReject as u8,
+            transfer_id: req.transfer_id.clone(),
+        };
+        FrameCodec::write_frame(&mut stream, &reject).await?;
+        info!("Rejected file transfer {}", req.transfer_id);
+        return Ok(());
+    }
+
+    // Accept
+    let accept = FileResponse {
+        msg_type: MessageType::FileAccept as u8,
+        transfer_id: req.transfer_id.clone(),
+    };
+    FrameCodec::write_frame(&mut stream, &accept).await?;
+
+    // Prepare local file
+    tokio::fs::create_dir_all(&download_dir).await?;
+    let save_path = download_dir.join(&req.filename);
+    let mut file = File::create(&save_path).await?;
+    let mut hasher = Sha256::new();
+    let mut bytes_received: u64 = 0;
+    let chunk_size = if req.chunk_size > 0 {
+        req.chunk_size
+    } else {
+        DEFAULT_CHUNK_SIZE
+    };
+    let total_chunks = ((req.file_size + chunk_size as u64 - 1) / chunk_size as u64) as u32;
+
+    // Track state
+    transfers.write().await.insert(
+        req.transfer_id.clone(),
+        TransferState {
+            transfer_id: req.transfer_id.clone(),
+            filename: req.filename.clone(),
+            file_size: req.file_size,
+            bytes_transferred: 0,
+            status: "transferring".to_string(),
+            local_path: Some(save_path.clone()),
+        },
+    );
+
+    // Record in DB
+    let now = chrono::Utc::now().timestamp_millis();
+    let db_record = DbFileTransfer {
+        id: req.transfer_id.clone(),
+        message_id: req.transfer_id.clone(), // use transfer_id as message_id for now
+        file_name: req.filename.clone(),
+        file_size: req.file_size as i64,
+        checksum: req.checksum.clone(),
+        status: "transferring".to_string(),
+        bytes_transferred: 0,
+        local_path: Some(save_path.to_string_lossy().to_string()),
+        created_at: now,
+        updated_at: now,
+    };
+    let _ = db.insert_file_transfer(&db_record);
+
+    // Receive chunks
+    loop {
+        let chunk: FileData = match FrameCodec::read_frame(&mut stream).await {
+            Ok(c) => c,
+            Err(e) => {
+                // Check if it's a cancel or done
+                let err_str = e.to_string();
+                if let Some(on_fail) = &on_failed {
+                    on_fail(&req.transfer_id, &err_str);
+                }
+                let _ = db.update_transfer_progress(
+                    &req.transfer_id,
+                    bytes_received as i64,
+                    "failed",
+                );
+                return Err(e);
+            }
+        };
+
+        // Check for FileDone
+        if chunk.msg_type == MessageType::FileDone as u8 {
+            break;
+        }
+
+        if chunk.msg_type == MessageType::FileCancel as u8 {
+            info!("Transfer {} cancelled by sender", req.transfer_id);
+            let _ = db.update_transfer_progress(
+                &req.transfer_id,
+                bytes_received as i64,
+                "cancelled",
+            );
+            if let Some(on_fail) = &on_failed {
+                on_fail(&req.transfer_id, "Cancelled by sender");
+            }
+            return Ok(());
+        }
+
+        if chunk.msg_type != MessageType::FileData as u8 {
+            warn!("Unexpected msg_type {} during transfer", chunk.msg_type);
+            continue;
+        }
+
+        // Write chunk to file
+        file.write_all(&chunk.data).await?;
+        hasher.update(&chunk.data);
+        bytes_received += chunk.data.len() as u64;
+
+        // Send ACK
+        let ack = FileChunkAck {
+            msg_type: MessageType::FileAck as u8,
+            transfer_id: req.transfer_id.clone(),
+            seq: chunk.seq,
+            status: None,
+        };
+        FrameCodec::write_frame(&mut stream, &ack).await?;
+
+        // Progress callback
+        if let Some(prog) = &on_progress {
+            prog(&req.transfer_id, bytes_received, req.file_size);
+        }
+
+        // Update DB periodically (every 10 chunks)
+        if chunk.seq % 10 == 0 {
+            let _ = db.update_transfer_progress(
+                &req.transfer_id,
+                bytes_received as i64,
+                "transferring",
+            );
+        }
+    }
+
+    file.flush().await?;
+
+    // Verify checksum
+    let computed = format!("{:x}", hasher.finalize());
+    let verified = computed == req.checksum;
+
+    let final_ack = FileChunkAck {
+        msg_type: MessageType::FileAck as u8,
+        transfer_id: req.transfer_id.clone(),
+        seq: total_chunks,
+        status: Some(if verified {
+            "verified".to_string()
+        } else {
+            "checksum_mismatch".to_string()
+        }),
+    };
+    FrameCodec::write_frame(&mut stream, &final_ack).await?;
+
+    let status = if verified { "completed" } else { "failed" };
+    let _ = db.update_transfer_progress(&req.transfer_id, bytes_received as i64, status);
+
+    if verified {
+        info!("Transfer {} completed, {} bytes", req.transfer_id, bytes_received);
+        if let Some(comp) = &on_complete {
+            comp(&req.transfer_id);
+        }
+    } else {
+        warn!(
+            "Transfer {} checksum mismatch: expected {}, got {}",
+            req.transfer_id, req.checksum, computed
+        );
+        if let Some(fail) = &on_failed {
+            fail(&req.transfer_id, "Checksum mismatch");
+        }
+    }
+
+    transfers.write().await.remove(&req.transfer_id);
+    Ok(())
+}
+
+/// Send a file to a peer: connect, send FileReq, wait accept, stream chunks, verify.
+async fn send_file_to_peer(
+    req: SendRequest,
+    db: Arc<Database>,
+    on_progress: Option<OnProgress>,
+    on_complete: Option<OnComplete>,
+    on_failed: Option<OnFailed>,
+    transfers: Arc<RwLock<HashMap<String, TransferState>>>,
+) -> Result<()> {
+    let mut stream = TcpStream::connect(req.peer_addr)
+        .await
+        .with_context(|| format!("Connect to {} failed", req.peer_addr))?;
+
+    let metadata = tokio::fs::metadata(&req.file_path).await?;
+    let file_size = metadata.len();
+    let filename = req
+        .file_path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
+
+    // Compute SHA-256
+    let checksum = compute_file_checksum(&req.file_path).await?;
+
+    let chunk_size = DEFAULT_CHUNK_SIZE;
+    let total_chunks = ((file_size + chunk_size as u64 - 1) / chunk_size as u64) as u32;
+
+    // Send FileReq
+    let file_req = FileRequest {
+        msg_type: MessageType::FileReq as u8,
+        transfer_id: req.transfer_id.clone(),
+        from_id: req.peer_id.clone(),
+        filename: filename.clone(),
+        file_size,
+        checksum: checksum.clone(),
+        chunk_size,
+        resume_from_seq: None,
+    };
+    FrameCodec::write_frame(&mut stream, &file_req).await?;
+
+    // Wait for accept/reject
+    let response: FileResponse = FrameCodec::read_frame(&mut stream).await?;
+    if response.msg_type == MessageType::FileReject as u8 {
+        info!("File transfer {} rejected by peer", req.transfer_id);
+        let _ = db.update_transfer_progress(&req.transfer_id, 0, "rejected");
+        if let Some(fail) = &on_failed {
+            fail(&req.transfer_id, "Rejected by peer");
+        }
+        return Ok(());
+    }
+
+    // Record in DB
+    let now = chrono::Utc::now().timestamp_millis();
+    let db_record = DbFileTransfer {
+        id: req.transfer_id.clone(),
+        message_id: req.transfer_id.clone(),
+        file_name: filename,
+        file_size: file_size as i64,
+        checksum: checksum.clone(),
+        status: "transferring".to_string(),
+        bytes_transferred: 0,
+        local_path: Some(req.file_path.to_string_lossy().to_string()),
+        created_at: now,
+        updated_at: now,
+    };
+    let _ = db.insert_file_transfer(&db_record);
+
+    // Stream file chunks
+    let mut file = File::open(&req.file_path).await?;
+    let mut buf = vec![0u8; chunk_size as usize];
+    let mut seq: u32 = 0;
+    let mut bytes_sent: u64 = 0;
+
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+
+        let chunk = FileData {
+            msg_type: MessageType::FileData as u8,
+            transfer_id: req.transfer_id.clone(),
+            seq,
+            data: buf[..n].to_vec(),
+        };
+        FrameCodec::write_frame(&mut stream, &chunk).await?;
+
+        // Wait for chunk ACK
+        let ack: FileChunkAck = FrameCodec::read_frame(&mut stream).await?;
+        if ack.seq != seq {
+            warn!("ACK seq mismatch: expected {}, got {}", seq, ack.seq);
+        }
+
+        bytes_sent += n as u64;
+        seq += 1;
+
+        if let Some(prog) = &on_progress {
+            prog(&req.transfer_id, bytes_sent, file_size);
+        }
+
+        if seq % 10 == 0 {
+            let _ = db.update_transfer_progress(
+                &req.transfer_id,
+                bytes_sent as i64,
+                "transferring",
+            );
+        }
+    }
+
+    // Send FileDone
+    let done = FileDone {
+        msg_type: MessageType::FileDone as u8,
+        transfer_id: req.transfer_id.clone(),
+        checksum: checksum.clone(),
+    };
+    FrameCodec::write_frame(&mut stream, &done).await?;
+
+    // Wait for final ACK with verification status
+    let final_ack: FileChunkAck = FrameCodec::read_frame(&mut stream).await?;
+    let verified = final_ack
+        .status
+        .as_deref()
+        .map(|s| s == "verified")
+        .unwrap_or(false);
+
+    let status = if verified { "completed" } else { "failed" };
+    let _ = db.update_transfer_progress(&req.transfer_id, bytes_sent as i64, status);
+
+    if verified {
+        info!("Transfer {} completed successfully", req.transfer_id);
+        if let Some(comp) = &on_complete {
+            comp(&req.transfer_id);
+        }
+    } else {
+        warn!("Transfer {} verification failed", req.transfer_id);
+        if let Some(fail) = &on_failed {
+            fail(&req.transfer_id, "Verification failed on receiver");
+        }
+    }
+
+    transfers.write().await.remove(&req.transfer_id);
+    Ok(())
+}
+
+/// Compute SHA-256 checksum of a file.
+async fn compute_file_checksum(path: &Path) -> Result<String> {
+    let mut file = File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::db::Database;
+    use tokio::io::AsyncWriteExt;
+
+    #[tokio::test]
+    async fn test_file_transfer_send_receive() {
+        let db = Arc::new(Database::open_in_memory().unwrap());
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let download_dir = tmp_dir.path().join("downloads");
+
+        // Create a test file
+        let test_file = tmp_dir.path().join("test.txt");
+        let test_data = "Hello, this is a test file for transfer!\n".repeat(100);
+        tokio::fs::write(&test_file, &test_data).await.unwrap();
+
+        // Setup receiver
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let db_recv = db.clone();
+        let dl_dir = download_dir.clone();
+        let (complete_tx, mut complete_rx) = mpsc::channel::<String>(1);
+
+        tokio::spawn(async move {
+            let (stream, peer) = listener.accept().await.unwrap();
+            handle_incoming_transfer(
+                stream,
+                peer,
+                db_recv,
+                dl_dir,
+                None,
+                None, // auto-accept
+                Some(Arc::new(move |id| {
+                    let _ = complete_tx.try_send(id.to_string());
+                })),
+                None,
+                Arc::new(RwLock::new(HashMap::new())),
+            )
+            .await
+            .unwrap();
+        });
+
+        // Send file
+        let send_req = SendRequest {
+            peer_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
+            file_path: test_file.clone(),
+            transfer_id: "xfer-001".to_string(),
+            peer_id: "sender-1".to_string(),
+        };
+
+        send_file_to_peer(
+            send_req,
+            db.clone(),
+            None,
+            None,
+            None,
+            Arc::new(RwLock::new(HashMap::new())),
+        )
+        .await
+        .unwrap();
+
+        // Wait for completion
+        let completed_id =
+            tokio::time::timeout(std::time::Duration::from_secs(5), complete_rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(completed_id, "xfer-001");
+
+        // Verify downloaded file matches
+        let downloaded = tokio::fs::read_to_string(download_dir.join("test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(downloaded, test_data);
+    }
+
+    #[tokio::test]
+    async fn test_file_checksum() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        tokio::fs::write(tmp.path(), b"hello world").await.unwrap();
+        let checksum = compute_file_checksum(tmp.path()).await.unwrap();
+        // SHA-256 of "hello world"
+        assert_eq!(
+            checksum,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+}

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 mod commands;
 mod device;
 mod discovery;
+mod file_transfer;
 mod messenger;
 mod protocol;
 mod storage;
 
 use device::DeviceConfig;
+use file_transfer::FileTransferService;
 use messenger::MessengerService;
 use storage::Database;
 use std::path::PathBuf;
@@ -92,6 +94,43 @@ pub fn run() {
             let handle = tauri::async_runtime::block_on(messenger_svc.start())
                 .expect("Failed to start messenger service");
             app.manage(handle);
+
+            // Start file transfer service
+            let ft_db = Arc::new(Database::open(&db_path)
+                .expect("Failed to open database for file transfer"));
+            let download_dir = app_dir.join("downloads");
+            let mut ft_svc = FileTransferService::new(
+                file_transfer::service::FILE_PORT,
+                ft_db,
+                download_dir,
+            );
+
+            let ft_app = app.handle().clone();
+            ft_svc.on_progress(move |id, transferred, total| {
+                use tauri::Emitter;
+                let _ = ft_app.emit("file-transfer-progress", serde_json::json!({
+                    "transfer_id": id,
+                    "progress": transferred as f64 / total as f64,
+                    "bytes_transferred": transferred,
+                    "total_bytes": total,
+                }));
+            });
+
+            let ft_app2 = app.handle().clone();
+            ft_svc.on_complete(move |id| {
+                use tauri::Emitter;
+                let _ = ft_app2.emit("file-transfer-complete", serde_json::json!({ "transfer_id": id }));
+            });
+
+            let ft_app3 = app.handle().clone();
+            ft_svc.on_failed(move |id, reason| {
+                use tauri::Emitter;
+                let _ = ft_app3.emit("transfer-failed", serde_json::json!({ "transfer_id": id, "reason": reason }));
+            });
+
+            let ft_handle = tauri::async_runtime::block_on(ft_svc.start())
+                .expect("Failed to start file transfer service");
+            app.manage(ft_handle);
 
             Ok(())
         })

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,85 +1,92 @@
 <script setup lang="ts">
-import { RouterLink, RouterView } from 'vue-router'
-import HelloWorld from './components/HelloWorld.vue'
+import { ref } from 'vue'
+import ContactList from './views/ContactList.vue'
+import ChatView from './views/ChatView.vue'
+import FileTransfer from './views/FileTransfer.vue'
+
+const activeTab = ref<'chat' | 'files'>('chat')
 </script>
 
 <template>
-  <header>
-    <img alt="Vue logo" class="logo" src="@/assets/logo.svg" width="125" height="125" />
-
-    <div class="wrapper">
-      <HelloWorld msg="You did it!" />
-
-      <nav>
-        <RouterLink to="/">Home</RouterLink>
-        <RouterLink to="/about">About</RouterLink>
-      </nav>
+  <div class="app-layout">
+    <ContactList />
+    <div class="main-area">
+      <div class="tab-bar">
+        <button
+          :class="['tab', { active: activeTab === 'chat' }]"
+          @click="activeTab = 'chat'"
+        >
+          💬 Chat
+        </button>
+        <button
+          :class="['tab', { active: activeTab === 'files' }]"
+          @click="activeTab = 'files'"
+        >
+          📁 Files
+        </button>
+      </div>
+      <ChatView v-if="activeTab === 'chat'" />
+      <FileTransfer v-else />
     </div>
-  </header>
-
-  <RouterView />
+  </div>
 </template>
 
-<style scoped>
-header {
-  line-height: 1.5;
-  max-height: 100vh;
+<style>
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
-}
-
-nav {
+html, body, #app {
+  height: 100%;
   width: 100%;
-  font-size: 12px;
-  text-align: center;
-  margin-top: 2rem;
+  overflow: hidden;
 }
 
-nav a.router-link-exact-active {
-  color: var(--color-text);
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #0a0a1a;
+}
+</style>
+
+<style scoped>
+.app-layout {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
 }
 
-nav a.router-link-exact-active:hover {
-  background-color: transparent;
+.main-area {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
 }
 
-nav a {
-  display: inline-block;
-  padding: 0 1rem;
-  border-left: 1px solid var(--color-border);
+.tab-bar {
+  display: flex;
+  background: #1a1a2e;
+  border-bottom: 1px solid #16213e;
 }
 
-nav a:first-of-type {
-  border: 0;
+.tab {
+  padding: 10px 20px;
+  border: none;
+  background: transparent;
+  color: #888;
+  font-size: 14px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all 0.15s;
 }
 
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
+.tab:hover {
+  color: #ccc;
+}
 
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
-
-  nav {
-    text-align: left;
-    margin-left: -1rem;
-    font-size: 1rem;
-
-    padding: 1rem 0;
-    margin-top: 1rem;
-  }
+.tab.active {
+  color: #e0e0e0;
+  border-bottom-color: #533483;
 }
 </style>

--- a/frontend/src/stores/contacts.ts
+++ b/frontend/src/stores/contacts.ts
@@ -1,0 +1,74 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { contacts as contactsApi, events } from '../ipc'
+import type { Contact } from '../storage'
+
+export const useContactsStore = defineStore('contacts', () => {
+  const contacts = ref<Contact[]>([])
+  const selectedContactId = ref<string | null>(null)
+  const searchQuery = ref('')
+
+  const onlineContacts = computed(() => contacts.value.filter((c) => c.online))
+
+  const filteredContacts = computed(() => {
+    const q = searchQuery.value.toLowerCase()
+    if (!q) return contacts.value
+    return contacts.value.filter(
+      (c) => c.name.toLowerCase().includes(q) || c.ipAddress.toLowerCase().includes(q),
+    )
+  })
+
+  const selectedContact = computed(() =>
+    contacts.value.find((c) => c.id === selectedContactId.value) ?? null,
+  )
+
+  async function fetchContacts() {
+    contacts.value = await contactsApi.getAll()
+  }
+
+  function selectContact(id: string) {
+    selectedContactId.value = id
+  }
+
+  function setupListeners() {
+    events.onPeerFound((peer) => {
+      const existing = contacts.value.find((c) => c.id === peer.id)
+      if (existing) {
+        existing.online = true
+        existing.name = peer.name
+        existing.ipAddress = peer.ip_address
+        existing.port = peer.port
+      } else {
+        contacts.value.push({
+          id: peer.id,
+          name: peer.name,
+          ipAddress: peer.ip_address,
+          port: peer.port,
+          online: true,
+          lastSeen: Date.now(),
+          createdAt: Date.now(),
+        })
+      }
+    })
+
+    events.onPeerLost((peerId) => {
+      const contact = contacts.value.find((c) => c.id === peerId)
+      if (contact) {
+        contact.online = false
+        contact.lastSeen = Date.now()
+      }
+    })
+  }
+
+  return {
+    contacts,
+    selectedContactId,
+    searchQuery,
+    onlineContacts,
+    filteredContacts,
+    selectedContact,
+    fetchContacts,
+    selectContact,
+    setupListeners,
+  }
+})

--- a/frontend/src/stores/messages.ts
+++ b/frontend/src/stores/messages.ts
@@ -1,0 +1,69 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { messages as messagesApi, events } from '../ipc'
+import type { StoredMessage } from '../storage'
+
+export const useMessagesStore = defineStore('messages', () => {
+  /** Messages keyed by contact ID */
+  const messagesByContact = ref<Record<string, StoredMessage[]>>({})
+  const loading = ref(false)
+
+  function getMessages(contactId: string): StoredMessage[] {
+    return messagesByContact.value[contactId] ?? []
+  }
+
+  async function fetchMessages(contactId: string, limit = 50, offset = 0) {
+    loading.value = true
+    try {
+      const msgs = await messagesApi.query(contactId, limit, offset)
+      // Sort ascending by timestamp for display
+      msgs.sort((a, b) => a.timestamp - b.timestamp)
+      if (offset === 0) {
+        messagesByContact.value[contactId] = msgs
+      } else {
+        // Prepend older messages
+        const existing = messagesByContact.value[contactId] ?? []
+        messagesByContact.value[contactId] = [...msgs, ...existing]
+      }
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function sendMessage(recipientId: string, content: string) {
+    const msg = await messagesApi.send(recipientId, content)
+    const existing = messagesByContact.value[recipientId] ?? []
+    messagesByContact.value[recipientId] = [...existing, msg]
+    return msg
+  }
+
+  function setupListeners() {
+    events.onMessageReceived((msg) => {
+      const contactId = msg.senderId
+      const existing = messagesByContact.value[contactId] ?? []
+      // Avoid duplicates
+      if (!existing.find((m) => m.id === msg.id)) {
+        messagesByContact.value[contactId] = [...existing, msg]
+      }
+    })
+
+    events.onMessageSent((msg) => {
+      const contactId = msg.recipientId
+      const existing = messagesByContact.value[contactId] ?? []
+      const idx = existing.findIndex((m) => m.id === msg.id)
+      if (idx >= 0) {
+        existing[idx] = msg
+        messagesByContact.value[contactId] = [...existing]
+      }
+    })
+  }
+
+  return {
+    messagesByContact,
+    loading,
+    getMessages,
+    fetchMessages,
+    sendMessage,
+    setupListeners,
+  }
+})

--- a/frontend/src/stores/transfers.ts
+++ b/frontend/src/stores/transfers.ts
@@ -1,0 +1,78 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { fileTransfer as ftApi, events } from '../ipc'
+
+export interface Transfer {
+  id: string
+  fileName: string
+  fileSize: number
+  bytesTransferred: number
+  progress: number
+  status: 'pending' | 'transferring' | 'completed' | 'failed' | 'rejected' | 'cancelled'
+  direction: 'send' | 'receive'
+  peerId: string
+}
+
+export const useTransfersStore = defineStore('transfers', () => {
+  const transfers = ref<Transfer[]>([])
+
+  const activeTransfers = computed(() =>
+    transfers.value.filter((t) => t.status === 'pending' || t.status === 'transferring'),
+  )
+
+  async function sendFile(recipientId: string, filePath: string, fileName: string, fileSize: number) {
+    const transferId = await ftApi.initiate(recipientId, filePath)
+    transfers.value.push({
+      id: transferId,
+      fileName,
+      fileSize,
+      bytesTransferred: 0,
+      progress: 0,
+      status: 'pending',
+      direction: 'send',
+      peerId: recipientId,
+    })
+    return transferId
+  }
+
+  async function acceptTransfer(transferId: string) {
+    await ftApi.accept(transferId)
+    const t = transfers.value.find((t) => t.id === transferId)
+    if (t) t.status = 'transferring'
+  }
+
+  async function rejectTransfer(transferId: string) {
+    await ftApi.reject(transferId)
+    const t = transfers.value.find((t) => t.id === transferId)
+    if (t) t.status = 'rejected'
+  }
+
+  function setupListeners() {
+    events.onFileTransferProgress((p) => {
+      const t = transfers.value.find((t) => t.id === p.transfer_id)
+      if (t) {
+        t.bytesTransferred = p.bytes_transferred
+        t.progress = t.fileSize > 0 ? p.bytes_transferred / t.fileSize : 0
+        t.status = 'transferring'
+      }
+    })
+
+    events.onFileTransferComplete((transferId) => {
+      const t = transfers.value.find((t) => t.id === transferId)
+      if (t) {
+        t.status = 'completed'
+        t.progress = 1
+        t.bytesTransferred = t.fileSize
+      }
+    })
+  }
+
+  return {
+    transfers,
+    activeTransfers,
+    sendFile,
+    acceptTransfer,
+    rejectTransfer,
+    setupListeners,
+  }
+})

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -1,0 +1,303 @@
+<script setup lang="ts">
+import { ref, computed, watch, nextTick, onMounted } from 'vue'
+import { useContactsStore } from '../stores/contacts'
+import { useMessagesStore } from '../stores/messages'
+
+const contactsStore = useContactsStore()
+const messagesStore = useMessagesStore()
+
+const inputText = ref('')
+const messagesContainer = ref<HTMLElement | null>(null)
+
+const currentMessages = computed(() => {
+  const cid = contactsStore.selectedContactId
+  if (!cid) return []
+  return messagesStore.getMessages(cid)
+})
+
+onMounted(() => {
+  messagesStore.setupListeners()
+})
+
+// Auto-scroll on new messages
+watch(currentMessages, () => {
+  nextTick(() => {
+    if (messagesContainer.value) {
+      messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight
+    }
+  })
+}, { deep: true })
+
+async function sendMessage() {
+  const text = inputText.value.trim()
+  if (!text || !contactsStore.selectedContactId) return
+  inputText.value = ''
+  try {
+    await messagesStore.sendMessage(contactsStore.selectedContactId, text)
+  } catch (e) {
+    console.error('Failed to send message:', e)
+  }
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault()
+    sendMessage()
+  }
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+function formatDate(ts: number): string {
+  const d = new Date(ts)
+  const today = new Date()
+  if (d.toDateString() === today.toDateString()) return 'Today'
+  const yesterday = new Date(today)
+  yesterday.setDate(yesterday.getDate() - 1)
+  if (d.toDateString() === yesterday.toDateString()) return 'Yesterday'
+  return d.toLocaleDateString()
+}
+
+function shouldShowDate(index: number): boolean {
+  if (index === 0) return true
+  const prev = currentMessages.value[index - 1]
+  const curr = currentMessages.value[index]
+  return new Date(prev.timestamp).toDateString() !== new Date(curr.timestamp).toDateString()
+}
+</script>
+
+<template>
+  <div class="chat-view">
+    <!-- No contact selected -->
+    <div v-if="!contactsStore.selectedContact" class="empty-chat">
+      <div class="empty-icon">💬</div>
+      <p>Select a contact to start chatting</p>
+    </div>
+
+    <!-- Chat active -->
+    <template v-else>
+      <div class="chat-header">
+        <div class="header-info">
+          <span class="header-name">{{ contactsStore.selectedContact.name }}</span>
+          <span :class="['header-status', { online: contactsStore.selectedContact.online }]">
+            {{ contactsStore.selectedContact.online ? 'Online' : 'Offline' }}
+          </span>
+        </div>
+        <span class="header-ip">{{ contactsStore.selectedContact.ipAddress }}</span>
+      </div>
+
+      <div ref="messagesContainer" class="messages-container">
+        <template v-for="(msg, index) in currentMessages" :key="msg.id">
+          <div v-if="shouldShowDate(index)" class="date-separator">
+            <span>{{ formatDate(msg.timestamp) }}</span>
+          </div>
+          <div :class="['message-bubble', msg.senderId === 'self' ? 'sent' : 'received']">
+            <div class="message-content">{{ msg.content }}</div>
+            <div class="message-meta">
+              <span class="message-time">{{ formatTime(msg.timestamp) }}</span>
+              <span v-if="msg.senderId === 'self'" class="message-status">
+                {{ msg.status === 'sent' ? '✓' : msg.status === 'delivered' ? '✓✓' : '' }}
+              </span>
+            </div>
+          </div>
+        </template>
+
+        <div v-if="currentMessages.length === 0" class="no-messages">
+          <p>No messages yet. Say hello! 👋</p>
+        </div>
+      </div>
+
+      <div class="input-bar">
+        <textarea
+          v-model="inputText"
+          class="message-input"
+          placeholder="Type a message..."
+          rows="1"
+          @keydown="handleKeydown"
+        />
+        <button class="send-btn" :disabled="!inputText.trim()" @click="sendMessage">
+          Send
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.chat-view {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+  background: #16213e;
+}
+
+.empty-chat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #666;
+}
+
+.empty-icon {
+  font-size: 48px;
+  margin-bottom: 12px;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  background: #1a1a2e;
+  border-bottom: 1px solid #0f3460;
+}
+
+.header-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.header-name {
+  color: #e0e0e0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.header-status {
+  font-size: 12px;
+  color: #666;
+}
+
+.header-status.online {
+  color: #4ecca3;
+}
+
+.header-ip {
+  font-size: 12px;
+  color: #555;
+}
+
+.messages-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.date-separator {
+  text-align: center;
+  padding: 8px 0;
+  color: #555;
+  font-size: 12px;
+}
+
+.date-separator span {
+  background: #1a1a2e;
+  padding: 2px 12px;
+  border-radius: 10px;
+}
+
+.message-bubble {
+  max-width: 70%;
+  padding: 8px 12px;
+  border-radius: 12px;
+  word-wrap: break-word;
+}
+
+.message-bubble.sent {
+  align-self: flex-end;
+  background: #533483;
+  color: #e0e0e0;
+  border-bottom-right-radius: 4px;
+}
+
+.message-bubble.received {
+  align-self: flex-start;
+  background: #0f3460;
+  color: #e0e0e0;
+  border-bottom-left-radius: 4px;
+}
+
+.message-content {
+  font-size: 14px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.message-meta {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: 4px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.no-messages {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: #555;
+}
+
+.input-bar {
+  display: flex;
+  align-items: flex-end;
+  padding: 12px 16px;
+  gap: 8px;
+  background: #1a1a2e;
+  border-top: 1px solid #0f3460;
+}
+
+.message-input {
+  flex: 1;
+  padding: 10px 14px;
+  border: 1px solid #0f3460;
+  border-radius: 12px;
+  background: #16213e;
+  color: #e0e0e0;
+  font-size: 14px;
+  resize: none;
+  outline: none;
+  max-height: 120px;
+  font-family: inherit;
+}
+
+.message-input:focus {
+  border-color: #533483;
+}
+
+.message-input::placeholder {
+  color: #555;
+}
+
+.send-btn {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 12px;
+  background: #533483;
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.send-btn:hover:not(:disabled) {
+  background: #6c44a2;
+}
+
+.send-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/views/ContactList.vue
+++ b/frontend/src/views/ContactList.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useContactsStore } from '../stores/contacts'
+import { useMessagesStore } from '../stores/messages'
+
+const contactsStore = useContactsStore()
+const messagesStore = useMessagesStore()
+
+onMounted(() => {
+  contactsStore.fetchContacts()
+  contactsStore.setupListeners()
+})
+
+function selectContact(id: string) {
+  contactsStore.selectContact(id)
+  messagesStore.fetchMessages(id)
+}
+
+function formatLastSeen(ts: number): string {
+  if (!ts) return ''
+  const d = new Date(ts)
+  const now = Date.now()
+  const diff = now - ts
+  if (diff < 60_000) return 'Just now'
+  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}m ago`
+  if (diff < 86400_000) return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  return d.toLocaleDateString()
+}
+</script>
+
+<template>
+  <div class="contact-list">
+    <div class="search-bar">
+      <input
+        v-model="contactsStore.searchQuery"
+        type="text"
+        placeholder="Search contacts..."
+        class="search-input"
+      />
+    </div>
+
+    <div class="contacts-header">
+      <span class="header-title">Contacts</span>
+      <span class="online-count">{{ contactsStore.onlineContacts.length }} online</span>
+    </div>
+
+    <div class="contacts-scroll">
+      <div
+        v-for="contact in contactsStore.filteredContacts"
+        :key="contact.id"
+        :class="['contact-item', { selected: contact.id === contactsStore.selectedContactId }]"
+        @click="selectContact(contact.id)"
+      >
+        <div class="contact-avatar">
+          <div :class="['status-dot', { online: contact.online }]" />
+          <span class="avatar-text">{{ contact.name.charAt(0).toUpperCase() }}</span>
+        </div>
+        <div class="contact-info">
+          <div class="contact-name">{{ contact.name }}</div>
+          <div class="contact-meta">
+            <span class="contact-ip">{{ contact.ipAddress }}</span>
+            <span v-if="!contact.online" class="last-seen">{{ formatLastSeen(contact.lastSeen) }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="contactsStore.filteredContacts.length === 0" class="empty-state">
+        <p v-if="contactsStore.searchQuery">No contacts match "{{ contactsStore.searchQuery }}"</p>
+        <p v-else>No devices found on the network</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.contact-list {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #1a1a2e;
+  border-right: 1px solid #16213e;
+  width: 280px;
+  min-width: 280px;
+}
+
+.search-bar {
+  padding: 12px;
+  border-bottom: 1px solid #16213e;
+}
+
+.search-input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #16213e;
+  border-radius: 8px;
+  background: #0f3460;
+  color: #e0e0e0;
+  font-size: 14px;
+  outline: none;
+}
+
+.search-input:focus {
+  border-color: #533483;
+}
+
+.search-input::placeholder {
+  color: #666;
+}
+
+.contacts-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.online-count {
+  color: #4ecca3;
+  font-weight: 600;
+}
+
+.contacts-scroll {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.contact-item {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: background 0.15s;
+  gap: 10px;
+}
+
+.contact-item:hover {
+  background: #16213e;
+}
+
+.contact-item.selected {
+  background: #0f3460;
+}
+
+.contact-avatar {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #533483;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.avatar-text {
+  color: white;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.status-dot {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #666;
+  border: 2px solid #1a1a2e;
+}
+
+.status-dot.online {
+  background: #4ecca3;
+}
+
+.contact-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.contact-name {
+  color: #e0e0e0;
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.contact-meta {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  color: #666;
+  margin-top: 2px;
+}
+
+.empty-state {
+  padding: 24px 12px;
+  text-align: center;
+  color: #666;
+  font-size: 14px;
+}
+</style>

--- a/frontend/src/views/FileTransfer.vue
+++ b/frontend/src/views/FileTransfer.vue
@@ -1,0 +1,282 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useTransfersStore, type Transfer } from '../stores/transfers'
+import { useContactsStore } from '../stores/contacts'
+
+const transfersStore = useTransfersStore()
+const contactsStore = useContactsStore()
+
+const fileInput = ref<HTMLInputElement | null>(null)
+
+onMounted(() => {
+  transfersStore.setupListeners()
+})
+
+function triggerFilePicker() {
+  fileInput.value?.click()
+}
+
+async function handleFileSelect(e: Event) {
+  const input = e.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file || !contactsStore.selectedContactId) return
+
+  // In Tauri, we'd use the dialog API. For now, use the file path.
+  // Note: web File API doesn't give real path; Tauri dialog does.
+  await transfersStore.sendFile(
+    contactsStore.selectedContactId,
+    (file as any).path ?? file.name, // Tauri provides path
+    file.name,
+    file.size,
+  )
+  input.value = ''
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+function formatSpeed(transfer: Transfer): string {
+  // Rough estimate — in production we'd track time intervals
+  if (transfer.bytesTransferred === 0) return ''
+  return formatFileSize(transfer.bytesTransferred) + ' transferred'
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'completed': return '✅'
+    case 'failed': return '❌'
+    case 'rejected': return '🚫'
+    case 'cancelled': return '⚪'
+    case 'transferring': return '📤'
+    case 'pending': return '⏳'
+    default: return '📄'
+  }
+}
+
+function getPeerName(peerId: string): string {
+  const contact = contactsStore.contacts.find((c) => c.id === peerId)
+  return contact?.name ?? peerId.slice(0, 8)
+}
+
+async function cancelTransfer(transferId: string) {
+  await transfersStore.rejectTransfer(transferId)
+}
+</script>
+
+<template>
+  <div class="file-transfer">
+    <div class="transfer-header">
+      <h3>File Transfer</h3>
+      <button
+        class="send-file-btn"
+        :disabled="!contactsStore.selectedContactId"
+        @click="triggerFilePicker"
+      >
+        📎 Send File
+      </button>
+      <input ref="fileInput" type="file" hidden @change="handleFileSelect" />
+    </div>
+
+    <!-- Active transfers -->
+    <div v-if="transfersStore.activeTransfers.length > 0" class="section">
+      <h4 class="section-title">Active</h4>
+      <div
+        v-for="t in transfersStore.activeTransfers"
+        :key="t.id"
+        class="transfer-item active"
+      >
+        <div class="transfer-icon">{{ statusIcon(t.status) }}</div>
+        <div class="transfer-info">
+          <div class="transfer-name">{{ t.fileName }}</div>
+          <div class="transfer-meta">
+            <span>{{ t.direction === 'send' ? '→' : '←' }} {{ getPeerName(t.peerId) }}</span>
+            <span>{{ formatFileSize(t.fileSize) }}</span>
+          </div>
+          <div class="progress-bar">
+            <div class="progress-fill" :style="{ width: `${t.progress * 100}%` }" />
+          </div>
+          <div class="transfer-progress-text">
+            {{ (t.progress * 100).toFixed(1) }}% — {{ formatSpeed(t) }}
+          </div>
+        </div>
+        <button class="cancel-btn" @click="cancelTransfer(t.id)">✕</button>
+      </div>
+    </div>
+
+    <!-- Completed / history -->
+    <div class="section">
+      <h4 class="section-title">History</h4>
+      <div
+        v-for="t in transfersStore.transfers.filter(
+          (t) => t.status !== 'pending' && t.status !== 'transferring',
+        )"
+        :key="t.id"
+        class="transfer-item"
+      >
+        <div class="transfer-icon">{{ statusIcon(t.status) }}</div>
+        <div class="transfer-info">
+          <div class="transfer-name">{{ t.fileName }}</div>
+          <div class="transfer-meta">
+            <span>{{ t.direction === 'send' ? '→' : '←' }} {{ getPeerName(t.peerId) }}</span>
+            <span>{{ formatFileSize(t.fileSize) }}</span>
+            <span class="transfer-status">{{ t.status }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        v-if="transfersStore.transfers.filter((t) => t.status !== 'pending' && t.status !== 'transferring').length === 0"
+        class="empty-state"
+      >
+        <p>No transfer history</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.file-transfer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #16213e;
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.transfer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.transfer-header h3 {
+  color: #e0e0e0;
+  font-size: 18px;
+  margin: 0;
+}
+
+.send-file-btn {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 8px;
+  background: #533483;
+  color: white;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.send-file-btn:hover:not(:disabled) {
+  background: #6c44a2;
+}
+
+.send-file-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.section {
+  margin-bottom: 20px;
+}
+
+.section-title {
+  color: #888;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0 0 8px 0;
+}
+
+.transfer-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 8px;
+  background: #1a1a2e;
+  margin-bottom: 6px;
+}
+
+.transfer-item.active {
+  border-left: 3px solid #4ecca3;
+}
+
+.transfer-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.transfer-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.transfer-name {
+  color: #e0e0e0;
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.transfer-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: #666;
+  margin-top: 2px;
+}
+
+.transfer-status {
+  text-transform: capitalize;
+}
+
+.progress-bar {
+  height: 4px;
+  background: #0f3460;
+  border-radius: 2px;
+  margin-top: 6px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: #4ecca3;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.transfer-progress-text {
+  font-size: 11px;
+  color: #4ecca3;
+  margin-top: 2px;
+}
+
+.cancel-btn {
+  background: none;
+  border: none;
+  color: #e74c3c;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.cancel-btn:hover {
+  background: rgba(231, 76, 60, 0.15);
+}
+
+.empty-state {
+  text-align: center;
+  color: #555;
+  padding: 16px;
+  font-size: 14px;
+}
+</style>


### PR DESCRIPTION
## 改了什么

### T8 - ContactList.vue (#9)
- 在线/离线状态实时更新
- 搜索过滤（名称/IP）
- 选中高亮，last seen 时间戳

### T9 - ChatView.vue (#10)
- 消息气泡（发送/接收），时间戳
- 自动滚动到底部
- 日期分隔线
- 送达状态指示（✓/✓✓）
- Enter 发送，Shift+Enter 换行

### T10 - FileTransfer.vue (#11)
- 文件选择发送
- 实时进度条
- 传输历史
- 取消传输
- 文件大小格式化

### 支撑
- Pinia stores: contacts, messages, transfers
- 暗色主题，Tab 布局（Chat / Files）
- 接入 Tauri IPC 事件实时更新

## 为什么一个 PR
三个前端视图共享 stores 和 App.vue 布局改动，强耦合拆不开。如凌瞰要求拆分可以再调整。

## 怎么测
- `cd frontend && npm run dev` 启动前端
- 验证联系人列表、聊天、文件传输 UI 完整
- 搭配后端验证 IPC 事件推送

Closes #9, closes #10, closes #11