### PR TITLE
fix: QA round 2 - tempfile dep, type guards, null check

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1893,6 +1893,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tempfile",
  "tokio",
  "uuid",
 ]
@@ -1962,6 +1963,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3058,6 +3065,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3919,6 +3939,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -32,3 +32,6 @@ sha2 = "0.10"
 anyhow = "1"
 serde_bytes = "0.11"
 hostname = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/frontend/src/protocol/codec.ts
+++ b/frontend/src/protocol/codec.ts
@@ -62,9 +62,11 @@ export function decodeFrame(buffer: Uint8Array): { message: Message; bytesConsum
 
   // Verify magic (2 bytes)
   for (let i = 0; i < 2; i++) {
-    if (buffer[i] !== FRAME_MAGIC[i]) {
+    const expected = FRAME_MAGIC[i]!
+    const actual = buffer[i]!
+    if (actual !== expected) {
       throw new ProtocolError(
-        `Invalid magic at offset ${i}: expected 0x${FRAME_MAGIC[i].toString(16)}, got 0x${buffer[i].toString(16)}`,
+        `Invalid magic at offset ${i}: expected 0x${expected.toString(16)}, got 0x${actual.toString(16)}`,
       )
     }
   }

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -64,6 +64,7 @@ function shouldShowDate(index: number): boolean {
   if (index === 0) return true
   const prev = currentMessages.value[index - 1]
   const curr = currentMessages.value[index]
+  if (!prev || !curr) return false
   return new Date(prev.timestamp).toDateString() !== new Date(curr.timestamp).toDateString()
 }
 </script>


### PR DESCRIPTION
## 修复内容

1. `Cargo.toml`: 添加 `[dev-dependencies] tempfile = "3"`（Rust 测试编译）
2. `protocol/codec.ts:67`: FRAME_MAGIC[i]/buffer[i] 非空断言
3. `ChatView.vue:67`: prev/curr 空值检查

## 本地验证

- `cargo build`: ✅ 0 errors
- `vue-tsc --build`: ✅
- `vitest run`: ✅ 62 tests

## 备注

repo 默认分支需手动改为 main（token 无 admin 权限）