### PR TITLE
fix(T6): fix file transfer 'early eof' in test_file_transfer_send_receive

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1893,6 +1893,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tempfile",
  "tokio",
  "uuid",
 ]
@@ -1962,6 +1963,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3058,6 +3065,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3919,6 +3939,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -32,3 +32,6 @@ sha2 = "0.10"
 anyhow = "1"
 serde_bytes = "0.11"
 hostname = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/frontend/src-tauri/src/file_transfer/service.rs
+++ b/frontend/src-tauri/src/file_transfer/service.rs
@@ -320,10 +320,9 @@ async fn handle_incoming_transfer(
 
     // Receive chunks
     loop {
-        let chunk: FileData = match FrameCodec::read_frame(&mut stream).await {
-            Ok(c) => c,
+        let raw = match FrameCodec::read_raw_frame(&mut stream).await {
+            Ok(r) => r,
             Err(e) => {
-                // Check if it's a cancel or done
                 let err_str = e.to_string();
                 if let Some(on_fail) = &on_failed {
                     on_fail(&req.transfer_id, &err_str);
@@ -337,12 +336,14 @@ async fn handle_incoming_transfer(
             }
         };
 
+        let msg_type = FrameCodec::peek_msg_type(&raw)?;
+
         // Check for FileDone
-        if chunk.msg_type == MessageType::FileDone as u8 {
+        if msg_type == MessageType::FileDone as u8 {
             break;
         }
 
-        if chunk.msg_type == MessageType::FileCancel as u8 {
+        if msg_type == MessageType::FileCancel as u8 {
             info!("Transfer {} cancelled by sender", req.transfer_id);
             let _ = db.update_transfer_progress(
                 &req.transfer_id,
@@ -355,10 +356,12 @@ async fn handle_incoming_transfer(
             return Ok(());
         }
 
-        if chunk.msg_type != MessageType::FileData as u8 {
-            warn!("Unexpected msg_type {} during transfer", chunk.msg_type);
+        if msg_type != MessageType::FileData as u8 {
+            warn!("Unexpected msg_type {} during transfer", msg_type);
             continue;
         }
+
+        let chunk: FileData = FrameCodec::decode(&raw)?;
 
         // Write chunk to file
         file.write_all(&chunk.data).await?;

--- a/frontend/src-tauri/src/protocol/codec.rs
+++ b/frontend/src-tauri/src/protocol/codec.rs
@@ -43,6 +43,59 @@ impl FrameCodec {
         Ok(rmp_serde::from_slice(&payload)?)
     }
 
+    /// Read one frame as raw payload bytes (for when you need to peek msg_type before deserializing).
+    pub async fn read_raw_frame<R: AsyncReadExt + Unpin>(
+        reader: &mut R,
+    ) -> Result<Vec<u8>> {
+        let mut header = [0u8; HEADER_SIZE];
+        reader.read_exact(&mut header).await?;
+        if header[0] != FRAME_MAGIC[0] || header[1] != FRAME_MAGIC[1] {
+            bail!("Invalid magic: {:02X}{:02X}", header[0], header[1]);
+        }
+        let len = u32::from_be_bytes([header[2], header[3], header[4], header[5]]);
+        if len > MAX_PAYLOAD_SIZE {
+            bail!("Payload length {} exceeds max {}", len, MAX_PAYLOAD_SIZE);
+        }
+        let mut payload = vec![0u8; len as usize];
+        reader.read_exact(&mut payload).await?;
+        Ok(payload)
+    }
+
+    /// Peek the msg_type (first field) from a raw MessagePack payload.
+    /// All protocol structs serialize as arrays with msg_type as the first element.
+    pub fn peek_msg_type(payload: &[u8]) -> Result<u8> {
+        if payload.is_empty() {
+            bail!("Empty payload");
+        }
+        // Skip array header to get to first element
+        let offset = if payload[0] & 0xF0 == 0x90 {
+            1 // fixarray (up to 15 elements)
+        } else if payload[0] == 0xdc {
+            3 // array 16
+        } else if payload[0] == 0xdd {
+            5 // array 32
+        } else {
+            bail!("Expected array header, got 0x{:02X}", payload[0]);
+        };
+        if offset >= payload.len() {
+            bail!("Payload too short to contain msg_type");
+        }
+        // Read the first element as a positive fixint or u8
+        let b = payload[offset];
+        if b <= 0x7f {
+            Ok(b) // positive fixint
+        } else if b == 0xcc && offset + 1 < payload.len() {
+            Ok(payload[offset + 1]) // uint 8
+        } else {
+            bail!("Unexpected msg_type encoding: 0x{:02X}", b);
+        }
+    }
+
+    /// Deserialize raw payload into a typed message.
+    pub fn decode<T: serde::de::DeserializeOwned>(payload: &[u8]) -> Result<T> {
+        Ok(rmp_serde::from_slice(payload)?)
+    }
+
     /// Write one frame to an async writer.
     pub async fn write_frame<W: AsyncWriteExt + Unpin, T: serde::Serialize>(
         writer: &mut W,
@@ -92,5 +145,35 @@ mod tests {
         let mut cursor = std::io::Cursor::new(buf);
         let decoded: TextMessage = FrameCodec::read_frame(&mut cursor).await.unwrap();
         assert_eq!(decoded.msg_id, "async-test");
+    }
+
+    #[test]
+    fn test_peek_msg_type() {
+        use crate::protocol::types::{FileDone, FileData};
+
+        let text_msg = TextMessage {
+            msg_type: MessageType::TextMsg as u8,
+            msg_id: "t1".into(), from_id: "u1".into(),
+            timestamp: 0, content: "hi".into(),
+        };
+        let payload = rmp_serde::to_vec(&text_msg).unwrap();
+        assert_eq!(FrameCodec::peek_msg_type(&payload).unwrap(), MessageType::TextMsg as u8);
+
+        let done = FileDone {
+            msg_type: MessageType::FileDone as u8,
+            transfer_id: "x1".into(),
+            checksum: "abc".into(),
+        };
+        let payload = rmp_serde::to_vec(&done).unwrap();
+        assert_eq!(FrameCodec::peek_msg_type(&payload).unwrap(), MessageType::FileDone as u8);
+
+        let data = FileData {
+            msg_type: MessageType::FileData as u8,
+            transfer_id: "x2".into(),
+            seq: 0,
+            data: vec![1, 2, 3],
+        };
+        let payload = rmp_serde::to_vec(&data).unwrap();
+        assert_eq!(FrameCodec::peek_msg_type(&payload).unwrap(), MessageType::FileData as u8);
     }
 }


### PR DESCRIPTION
## 改了什么
修复 `file_transfer::service::tests::test_file_transfer_send_receive` 测试的 'early eof' 错误。

## 根因
接收端 chunk 循环里 `FrameCodec::read_frame::<FileData>()` 固定反序列化为 `FileData` 类型。当发送端发 `FileDone`（不同字段结构），MessagePack 反序列化失败 → 'early eof'。

**这是真实 bug，不是 flaky test。**

## 修复
- 新增 `read_raw_frame()`：先读原始帧字节
- 新增 `peek_msg_type()`：从 MessagePack 数组第一个元素提取 msg_type
- 新增 `decode()`：按正确类型反序列化
- 接收端 loop 改为：read_raw → peek type → 按类型分发

## 验证
- `cargo check` ✅
- `cargo test` 6/6 ✅
- 连续 3 次运行稳定通过