### PR TITLE
fix(build): enable socket2 "all" feature for macOS

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 rmp-serde = "1"
-socket2 = "0.5"
+socket2 = { version = "0.5", features = ["all"] }
 tokio = { version = "1", features = ["full"] }
 sha2 = "0.10"
 anyhow = "1"


### PR DESCRIPTION
## Summary

`socket2::Socket::set_reuse_port` is gated behind the `all` feature in the `socket2` crate. The macOS-only call at `frontend/src-tauri/src/discovery/udp.rs:287` fails to compile on macOS without it (the method is not present on non-Unix builds).

## Fix

Enable the `all` feature on the `socket2` dependency.

```toml
socket2 = { version = "0.5", features = ["all"] }
```

## Verification

- `cargo check` on macOS ✅ (previously failed with E0599)
- No change to runtime behavior — `set_reuse_port` was already being called on macOS, just not compiling.

## Notes

This supersedes the build-fix commit in #41. That PR's UI changes were made obsolete by #40 (T29-4/5/6/7 components), so #41 will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)