### PR TITLE
fix(linklan): file card — send sender's own device_id + seed outgoing bubble

### DIFF
--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -176,12 +176,20 @@ pub struct FileTransferRequest {
     pub file_path: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct InitiateFileTransferResponse {
+    pub transfer_id: String,
+    pub file_name: String,
+    pub file_size: u64,
+}
+
 #[command]
 pub async fn initiate_file_transfer(
     request: FileTransferRequest,
     app: AppHandle,
     db: tauri::State<'_, Database>,
-) -> Result<String, String> {
+    device: tauri::State<'_, DeviceConfig>,
+) -> Result<InitiateFileTransferResponse, String> {
     let contact = db.get_contact(&request.recipient_id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("Contact {} not found", request.recipient_id))?;
@@ -190,15 +198,36 @@ pub async fn initiate_file_transfer(
         .parse()
         .map_err(|e: std::net::AddrParseError| e.to_string())?;
 
+    let file_path = std::path::PathBuf::from(&request.file_path);
+    // Stat the file here so the frontend can seed the outgoing chat card with
+    // the real file_name + file_size immediately, rather than waiting for the
+    // first `file-transfer-progress` event.
+    let metadata = tokio::fs::metadata(&file_path)
+        .await
+        .map_err(|e| format!("stat {}: {}", request.file_path, e))?;
+    let file_size = metadata.len();
+    let file_name = file_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| request.file_path.clone());
+
     let ft = app.state::<FileTransferHandle>();
+    // Third arg becomes `FileRequest.from_id` on the wire — must be the
+    // **sender's** device_id, not the recipient's. Previously passed
+    // `request.recipient_id`, which made the receiver index the inline file
+    // card against its own device_id and the card never rendered.
     let transfer_id = ft.send_file(
         peer_addr,
-        std::path::PathBuf::from(&request.file_path),
-        request.recipient_id,
+        file_path,
+        device.device_id.clone(),
     ).await.map_err(|e| e.to_string())?;
 
     let _ = app.emit("file-transfer-initiated", &transfer_id);
-    Ok(transfer_id)
+    Ok(InitiateFileTransferResponse {
+        transfer_id,
+        file_name,
+        file_size,
+    })
 }
 
 /// Validate a save_path coming from the IPC boundary. The native save

--- a/frontend/src-tauri/src/file_transfer/service.rs
+++ b/frontend/src-tauri/src/file_transfer/service.rs
@@ -65,7 +65,10 @@ struct SendRequest {
     peer_addr: SocketAddr,
     file_path: PathBuf,
     transfer_id: String,
-    peer_id: String,
+    /// **Our** device_id — gets written to `FileRequest.from_id` so the
+    /// receiver knows who sent the file. Previously mis-named / mis-used as
+    /// the recipient's id, which broke the receiver's inline card indexing.
+    sender_device_id: String,
 }
 
 pub struct FileTransferService {
@@ -86,11 +89,15 @@ pub struct FileTransferHandle {
 
 impl FileTransferHandle {
     /// Initiate sending a file to a peer.
+    ///
+    /// `sender_device_id` is this machine's device_id — it ends up in
+    /// `FileRequest.from_id` on the wire so the receiver can route the
+    /// inline card to the right conversation.
     pub async fn send_file(
         &self,
         peer_addr: SocketAddr,
         file_path: PathBuf,
-        peer_id: String,
+        sender_device_id: String,
     ) -> Result<String> {
         let transfer_id = uuid::Uuid::new_v4().to_string();
 
@@ -118,7 +125,7 @@ impl FileTransferHandle {
                 peer_addr,
                 file_path,
                 transfer_id: transfer_id.clone(),
-                peer_id,
+                sender_device_id,
             })
             .await
             .context("Outbound channel closed")?;
@@ -500,7 +507,7 @@ async fn send_file_to_peer(
     let file_req = FileRequest {
         msg_type: MessageType::FileReq as u8,
         transfer_id: req.transfer_id.clone(),
-        from_id: req.peer_id.clone(),
+        from_id: req.sender_device_id.clone(),
         filename: filename.clone(),
         file_size,
         checksum: checksum.clone(),
@@ -677,7 +684,7 @@ mod tests {
             peer_addr: format!("127.0.0.1:{}", port).parse().unwrap(),
             file_path: test_file.clone(),
             transfer_id: "xfer-001".to_string(),
-            peer_id: "sender-1".to_string(),
+            sender_device_id: "sender-1".to_string(),
         };
 
         send_file_to_peer(

--- a/frontend/src/api/fileTransfer.ts
+++ b/frontend/src/api/fileTransfer.ts
@@ -1,8 +1,14 @@
 import { invoke } from '@tauri-apps/api/core'
 
+export interface InitiateFileTransferResponse {
+  transfer_id: string
+  file_name: string
+  file_size: number
+}
+
 export const fileTransfer = {
   initiate: (recipientId: string, filePath: string) =>
-    invoke<string>('initiate_file_transfer', {
+    invoke<InitiateFileTransferResponse>('initiate_file_transfer', {
       request: { recipient_id: recipientId, file_path: filePath },
     }),
 

--- a/frontend/src/stores/__tests__/transfers.test.ts
+++ b/frontend/src/stores/__tests__/transfers.test.ts
@@ -45,13 +45,40 @@ beforeEach(() => {
 
 describe('useTransfersStore', () => {
   it('should send file and add transfer', async () => {
-    mockInvoke.mockResolvedValue('tx-001')
+    mockInvoke.mockResolvedValue({
+      transfer_id: 'tx-001',
+      file_name: 'file.txt',
+      file_size: 1234,
+    })
 
     await useTransfersStore.getState().sendFile('recipient', '/path/file.txt')
 
     expect(useTransfersStore.getState().transfers).toHaveLength(1)
-    expect(useTransfersStore.getState().transfers[0]!.id).toBe('tx-001')
-    expect(useTransfersStore.getState().transfers[0]!.direction).toBe('out')
+    const t = useTransfersStore.getState().transfers[0]!
+    expect(t.id).toBe('tx-001')
+    expect(t.direction).toBe('out')
+    expect(t.file_name).toBe('file.txt')
+    expect(t.file_size).toBe(1234)
+  })
+
+  it('sendFile also seeds an outgoing chat message so the sender renders a FileBubble', async () => {
+    mockInvoke.mockResolvedValue({
+      transfer_id: 'tx-002',
+      file_name: 'pic.png',
+      file_size: 42,
+    })
+
+    await useTransfersStore.getState().sendFile('recipient-7', '/tmp/pic.png')
+
+    const list = useMessagesStore.getState().messagesByContact['recipient-7']
+    expect(list).toBeDefined()
+    expect(list).toHaveLength(1)
+    expect(list![0]!).toMatchObject({
+      id: 'tx-002',
+      file_transfer_id: 'tx-002',
+      recipient_id: 'recipient-7',
+      content: 'pic.png',
+    })
   })
 
   it('acceptIncoming invokes accept_file_transfer with savePath and flips status', async () => {

--- a/frontend/src/stores/transfers.ts
+++ b/frontend/src/stores/transfers.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { listen } from '@tauri-apps/api/event'
 import { fileTransfer as api } from '../api/fileTransfer'
+import { useAppStore } from './app'
 import { useMessagesStore } from './messages'
 import type { FileTransfer, FileTransferProgress, StoredMessage } from '../types'
 
@@ -125,16 +126,19 @@ export const useTransfersStore = create<TransfersState>((set, get) => ({
   },
 
   sendFile: async (recipientId, filePath) => {
-    const transferId = await api.initiate(recipientId, filePath)
+    const { transfer_id: transferId, file_name, file_size } = await api.initiate(
+      recipientId,
+      filePath,
+    )
     const now = Date.now()
     set((s) => ({
       transfers: [
         ...s.transfers,
         {
           id: transferId,
-          message_id: '',
-          file_name: filePath.split('/').pop() ?? filePath,
-          file_size: 0,
+          message_id: transferId,
+          file_name,
+          file_size,
           checksum: '',
           status: 'pending',
           bytes_transferred: 0,
@@ -145,6 +149,31 @@ export const useTransfersStore = create<TransfersState>((set, get) => ({
         },
       ],
     }))
+
+    // Seed a synthetic outgoing message so the sender's chat renders a
+    // FileBubble card (symmetric to the inbound `file-request` path above).
+    // `sender_id` must be this device's real id so `toDisplayMessage` sees
+    // `from === 'me'` and renders the bubble on the right side.
+    const selfId = useAppStore.getState().deviceId ?? 'self'
+    const msg: StoredMessage = {
+      id: transferId,
+      sender_id: selfId,
+      recipient_id: recipientId,
+      content: file_name,
+      timestamp: now,
+      status: 'sent',
+      file_transfer_id: transferId,
+    }
+    useMessagesStore.setState((ms) => {
+      const existing = ms.messagesByContact[recipientId] ?? []
+      if (existing.some((m) => m.id === transferId)) return ms
+      return {
+        messagesByContact: {
+          ...ms.messagesByContact,
+          [recipientId]: [...existing, msg],
+        },
+      }
+    })
   },
 
   acceptIncoming: async (transferId, savePath) => {


### PR DESCRIPTION
## Summary
Post-#45 the inline file card never rendered on **either** side of a transfer. Two independent bugs:

1. **Receiver — wrong `from_id` on the wire.** `initiate_file_transfer` passed `request.recipient_id` (not the sender's own id) to `send_file`, so `FileRequest.from_id` arrived as the receiver's own `device_id`. The receiver's frontend keyed the synthetic FileBubble message off that field and filed the card under a bucket no open conversation was looking at. Log evidence: `file-request pending: ... from=<receiver's own id>` followed by a 5-min auto-reject.
2. **Sender — no outgoing bubble.** `transfers.ts::sendFile` inserted into `transfers[]` (visible in the file list) but never seeded a `StoredMessage` with a `file_transfer_id`, so `MessageList` had nothing to pivot into `FileBubble` — unlike the symmetric inbound `file-request` handler a few lines above it.

## Changes
- `commands.rs`: thread `DeviceConfig` into `initiate_file_transfer`, pass `device.device_id.clone()` as the 3rd arg to `send_file`. Return type widens to `{transfer_id, file_name, file_size}` so the outgoing bubble shows the real size on first paint.
- `file_transfer/service.rs`: rename the 3rd `SendRequest` / `send_file` param from `peer_id` → `sender_device_id` so the misuse is structurally harder to repeat. `FileRequest.from_id` now sources from that field.
- `stores/transfers.ts`: `sendFile` seeds a synthetic outgoing `StoredMessage` keyed by `useAppStore.deviceId` so `toDisplayMessage` resolves `from === 'me'` and the bubble renders right-aligned.
- `api/fileTransfer.ts`: new `InitiateFileTransferResponse` type to match the widened Rust return.

## Test plan
- [x] `cargo check --tests` — clean
- [x] `cargo test --lib file_transfer` — 2/2 pass (existing `test_file_transfer_send_receive` covers the rename)
- [x] `pnpm vitest run` — 43/43 pass, incl. new assertion in `transfers.test.ts` that `sendFile` seeds a `StoredMessage` with `file_transfer_id` into `messagesByContact[recipientId]`
- [x] `pnpm tsc --noEmit` — clean
- [x] End-to-end verified on LAN: macOS sender (192.168.50.138) → Ubuntu receiver (192.168.50.48). Receiver now renders the pending-response card with accept/reject buttons; sender renders the outgoing bubble immediately with real file size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)