### PR TITLE
fix(sender-card): stash local_path on the in-memory outgoing transfer

### DIFF
--- a/frontend/src/stores/transfers.ts
+++ b/frontend/src/stores/transfers.ts
@@ -150,6 +150,12 @@ export const useTransfersStore = create<TransfersState>((set, get) => ({
           bytes_transferred: 0,
           direction: 'out',
           peer_id: recipientId,
+          // Same-session `local_path`: the Rust side already persists the
+          // source path into the DB row, but the in-memory transfer is
+          // what FileBubble reads BEFORE any restart + rehydrate. Without
+          // stashing it here, clicking 在访达中显示 on a just-sent card
+          // trips the "文件位置未知" toast even though the path is known.
+          local_path: filePath,
           created_at: now,
           updated_at: now,
         },


### PR DESCRIPTION
## Summary
Clicking 在访达中显示 on a sender-side file card — in the same session it was sent in — showed the 「文件位置未知」 toast even though the source path was right there in the `ChatView` component that called `sendFile`.

## Root cause
`commands::initiate_file_transfer` writes the file_transfers DB row with `local_path = file_path`, and after app restart `useTransfersStore.hydrateFromDb` pulls that row back into memory — so **post-restart** the reveal button worked. But the **same-session** in-memory seed inside `sendFile` didn't copy `filePath` onto the synthetic transfer object, so `FileBubble` saw `transfer.local_path === undefined` and bailed with the toast.

## Fix
Pass `filePath` through to the seeded transfer row. One-line change in `stores/transfers.ts`. No backend change, no protocol change.

## Test plan
- [x] `pnpm vitest run` — 45/45
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manual: send a file → click the folder icon on the just-sent card → file manager opens to the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)